### PR TITLE
Add cdecimal support

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -42,6 +42,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 
 #define EPOCH_ORD 719163
 static PyObject* type_decimal = NULL;
+static PyObject* type_cdecimal = NULL;
 
 typedef void *(*PFN_PyTypeToJSON)(JSOBJ obj, JSONTypeContext *ti, void *outValue, size_t *_outLen);
 
@@ -89,6 +90,16 @@ void initObjToJSON(void)
     type_decimal = PyObject_GetAttrString(mod_decimal, "Decimal");
     Py_INCREF(type_decimal);
     Py_DECREF(mod_decimal);
+  }
+  else
+    PyErr_Clear();
+
+  PyObject* mod_cdecimal = PyImport_ImportModule("cdecimal");
+  if (mod_cdecimal)
+  {
+    type_cdecimal = PyObject_GetAttrString(mod_cdecimal, "Decimal");
+    Py_INCREF(type_cdecimal);
+    Py_DECREF(mod_cdecimal);    
   }
   else
     PyErr_Clear();
@@ -600,7 +611,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     return;
   }
   else
-  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)))
+  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)) || (type_cdecimal && PyObject_IsInstance(obj, type_cdecimal)))
   {
     PRINTMARK();
     pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -84,7 +84,10 @@ struct PyDictIterState
 
 void initObjToJSON(void)
 {
-  PyObject* mod_decimal = PyImport_ImportModule("decimal");
+  PyObject* mod_decimal;
+  PyObject* mod_cdecimal;
+  
+  mod_decimal = PyImport_ImportModule("decimal");
   if (mod_decimal)
   {
     type_decimal = PyObject_GetAttrString(mod_decimal, "Decimal");
@@ -94,7 +97,7 @@ void initObjToJSON(void)
   else
     PyErr_Clear();
 
-  PyObject* mod_cdecimal = PyImport_ImportModule("cdecimal");
+  mod_cdecimal = PyImport_ImportModule("cdecimal");
   if (mod_cdecimal)
   {
     type_cdecimal = PyObject_GetAttrString(mod_cdecimal, "Decimal");

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,6 +20,7 @@ import StringIO
 import re
 import random
 import decimal
+import cdecimal
 from functools import partial
 
 PY3 = (sys.version_info[0] >= 3)
@@ -35,6 +36,12 @@ class UltraJSONTests(TestCase):
 
     def test_encodeDecimal(self):
         sut = decimal.Decimal("1337.1337")
+        encoded = ujson.encode(sut, double_precision=100)
+        decoded = ujson.decode(encoded)
+        self.assertEquals(decoded, 1337.1337)
+
+    def test_encodeCDecimal(self):
+        sut = cdecimal.Decimal("1337.1337")
         encoded = ujson.encode(sut, double_precision=100)
         decoded = ujson.decode(encoded)
         self.assertEquals(decoded, 1337.1337)


### PR DESCRIPTION
Adds support for cdecimal.  Taken almost entirely from https://github.com/esnme/ultrajson/pull/120 but without the datetime changes that had been included there.

Note that this will make cdecimal a required dependency for running the tests.  Would it be better to change it to conditionally run only if the cdecimal import succeeds?
