### PR TITLE
added support to encode objects that implements  mapping protocol

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -162,7 +162,7 @@ static void *PyDateTimeToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, 
 
   date = PyDate_FromDate(y, m, 1);
   ord = PyObject_CallMethod(date, "toordinal", NULL);
-  days = PyInt_AS_LONG(ord) - EPOCH_ORD + d - 1;
+  days = (int)(PyInt_AS_LONG(ord) - EPOCH_ORD + d - 1);
   Py_DECREF(date);
   Py_DECREF(ord);
   *( (JSINT64 *) outValue) = (((JSINT64) ((days * 24 + h) * 60 + mn)) * 60 + s);
@@ -181,7 +181,7 @@ static void *PyDateToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size
 
   date = PyDate_FromDate(y, m, 1);
   ord = PyObject_CallMethod(date, "toordinal", NULL);
-  days = PyInt_AS_LONG(ord) - EPOCH_ORD + d - 1;
+  days = (int)(PyInt_AS_LONG(ord) - EPOCH_ORD + d - 1);
   Py_DECREF(date);
   Py_DECREF(ord);
   *( (JSINT64 *) outValue) = ((JSINT64) days * 86400);
@@ -410,12 +410,35 @@ char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 // itemValue is borrowed from object (which is dict). No refCounting
 //=============================================================================
 
-int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
+PyObject* Dict_ConvertItemName(PyObject* itemName)
 {
 #if PY_MAJOR_VERSION >= 3
   PyObject* itemNameTmp;
 #endif
 
+  if (PyUnicode_Check(itemName))
+  {
+    itemName = PyUnicode_AsUTF8String(itemName);
+  }
+  else
+  if (!PyString_Check(itemName))
+  {
+    itemName = PyObject_Str(itemName);
+#if PY_MAJOR_VERSION >= 3
+    itemNameTmp = itemName;
+    itemName = PyUnicode_AsUTF8String(itemName);
+    Py_DECREF(itemNameTmp);
+#endif
+  }
+  else
+  {
+    Py_INCREF(itemName);
+  }
+  return itemName;
+}
+
+int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
+{
   if (GET_TC(tc)->itemName)
   {
     Py_DECREF(GET_TC(tc)->itemName);
@@ -429,26 +452,9 @@ int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
     return 0;
   }
 
-  if (PyUnicode_Check(GET_TC(tc)->itemName))
-  {
-    GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
-  }
-  else
-    if (!PyString_Check(GET_TC(tc)->itemName))
-    {
-      GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
-#if PY_MAJOR_VERSION >= 3
-      itemNameTmp = GET_TC(tc)->itemName;
-      GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
-      Py_DECREF(itemNameTmp);
-#endif
-    }
-    else
-    {
-      Py_INCREF(GET_TC(tc)->itemName);
-    }
-    PRINTMARK();
-    return 1;
+  GET_TC(tc)->itemName = Dict_ConvertItemName(GET_TC(tc)->itemName);
+  PRINTMARK();
+  return 1;
 }
 
 void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc)
@@ -482,6 +488,69 @@ void SetupDictIter(PyObject *dictObj, TypeContext *pc)
   pc->iterGetName = Dict_iterGetName;
   pc->dictObj = dictObj;
   pc->index = 0;
+}
+
+
+//=============================================================================
+// Mapping protocol iteration functions
+//=============================================================================
+
+int Mapping_iterNext(JSOBJ obj, JSONTypeContext *tc)
+{
+  PyObject* item;
+
+  if (GET_TC(tc)->itemName)
+  {
+    Py_DECREF(GET_TC(tc)->itemName);
+    GET_TC(tc)->itemName = NULL;
+  }
+
+  if (GET_TC(tc)->itemValue)
+  {
+    Py_DECREF(GET_TC(tc)->itemValue);
+    GET_TC(tc)->itemValue = NULL;
+  }
+
+  if (!(item = PyIter_Next(GET_TC(tc)->iterator)))
+  {
+    PRINTMARK();
+    return 0;
+  }
+
+  GET_TC(tc)->itemName = Dict_ConvertItemName(PyTuple_GET_ITEM(item, 0));
+  GET_TC(tc)->itemValue = PyTuple_GET_ITEM(item, 1);
+  Py_INCREF(GET_TC(tc)->itemValue);
+  Py_DECREF(item);
+  PRINTMARK();
+  return 1;
+}
+
+void Mapping_iterEnd(JSOBJ obj, JSONTypeContext *tc)
+{
+  if (GET_TC(tc)->itemName)
+  {
+    Py_DECREF(GET_TC(tc)->itemName);
+    GET_TC(tc)->itemName = NULL;
+  }
+  if (GET_TC(tc)->itemValue)
+  {
+    Py_DECREF(GET_TC(tc)->itemValue);
+    GET_TC(tc)->itemValue = NULL;
+  }
+  Py_DECREF(GET_TC(tc)->iterator);
+  GET_TC(tc)->iterator = NULL;
+  PRINTMARK();
+}
+
+JSOBJ Mapping_iterGetValue(JSOBJ obj, JSONTypeContext *tc)
+{
+  return GET_TC(tc)->itemValue;
+}
+
+char *Mapping_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
+{
+  *outLen = PyString_GET_SIZE(GET_TC(tc)->itemName);
+  return PyString_AS_STRING(GET_TC(tc)->itemName);
 }
 
 void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
@@ -532,7 +601,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     PRINTMARK();
     pc->PyTypeToJSON = PyLongToINT64;
     tc->type = JT_LONG;
-    GET_TC(tc)->longValue = PyLong_AsLongLong(obj);
+    pc->longValue = PyLong_AsLongLong(obj);
 
     exc = PyErr_Occurred();
 
@@ -616,8 +685,7 @@ ISITERABLE:
     pc->iterNext = List_iterNext;
     pc->iterGetValue = List_iterGetValue;
     pc->iterGetName = List_iterGetName;
-    GET_TC(tc)->index =  0;
-    GET_TC(tc)->size = PyList_GET_SIZE( (PyObject *) obj);
+    pc->size = PyList_GET_SIZE( (PyObject *) obj);
     return;
   }
   else
@@ -629,9 +697,7 @@ ISITERABLE:
     pc->iterNext = Tuple_iterNext;
     pc->iterGetValue = Tuple_iterGetValue;
     pc->iterGetName = Tuple_iterGetName;
-    GET_TC(tc)->index = 0;
-    GET_TC(tc)->size = PyTuple_GET_SIZE( (PyObject *) obj);
-    GET_TC(tc)->itemValue = NULL;
+    pc->size = PyTuple_GET_SIZE( (PyObject *) obj);
 
     return;
   }
@@ -681,6 +747,29 @@ ISITERABLE:
 
   PRINTMARK();
   PyErr_Clear();
+
+  if (PyMapping_Check(obj))
+  {
+    PRINTMARK();
+    tc->type = JT_OBJECT;
+    pc->iterEnd = Mapping_iterEnd;
+    pc->iterNext = Mapping_iterNext;
+    pc->iterGetValue = Mapping_iterGetValue;
+    pc->iterGetName = Mapping_iterGetName;
+    PyObject* itemsView = PyObject_CallMethod(obj, "items", NULL);
+    if (!itemsView)
+    {
+      goto INVALID;
+    }
+    pc->iterator = PyObject_GetIter(itemsView);
+    Py_DECREF(itemsView);
+    if (!pc->iterator)
+    {
+      goto INVALID;
+    }
+    pc->size = PyMapping_Size(obj);
+    return;
+  }
 
   iter = PyObject_GetIter(obj);
 

--- a/python/version.h
+++ b/python/version.h
@@ -36,4 +36,4 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
  * Copyright (c) 1994 Sun Microsystems, Inc.
 */
 
-#define UJSON_VERSION "1.34"
+#define UJSON_VERSION "1.35"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,6 +26,11 @@ import random
 import decimal
 from functools import partial
 
+try:
+    from UserDict import UserDict
+except ImportError:
+    from collections import UserDict
+
 PY3 = (sys.version_info[0] >= 3)
 if PY3:
     xrange = range
@@ -1036,6 +1041,14 @@ class UltraJSONTests(unittest.TestCase):
     def test_encodingInvalidUnicodeCharacter(self):
         s = "\udc7f"
         self.assertRaises(UnicodeEncodeError, ujson.dumps, s)
+
+    def test_encodeMapping(self):
+        d = {u"key": 31337}
+
+        ud = UserDict(d)
+        output = ujson.encode(ud)
+        dec = ujson.decode(output)
+        self.assertEqual(dec, d)
 
 """
 def test_decodeNumericIntFrcOverflow(self):


### PR DESCRIPTION
Support serialising python objects that implements mapping protocol (for example UserDict and classes derived from UserDict) as JSON object.
