### PR TITLE
datetime -> epoch ignores timezone re#119

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -146,8 +146,13 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, si
 static void *PyDateTimeToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   PyObject *obj = (PyObject *) _obj;
-  PyObject *date, *ord;
+  PyObject *date, *ord, *utcoffset;
   int y, m, d, h, mn, s, days;
+
+  utcoffset = PyObject_CallMethod(obj, "utcoffset", NULL);
+  if(utcoffset != NULL){
+     obj = PyNumber_Subtract(obj, utcoffset);
+  }
 
   y = PyDateTime_GET_YEAR(obj);
   m = PyDateTime_GET_MONTH(obj);

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -150,8 +150,8 @@ static void *PyDateTimeToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, 
   int y, m, d, h, mn, s, days;
 
   utcoffset = PyObject_CallMethod(obj, "utcoffset", NULL);
-  if(utcoffset != NULL){
-     obj = PyNumber_Subtract(obj, utcoffset);
+  if(utcoffset != Py_None){
+    obj = PyNumber_Subtract(obj, utcoffset);
   }
 
   y = PyDateTime_GET_YEAR(obj);

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,6 +17,7 @@ import time
 import datetime
 import calendar
 import StringIO
+import pytz
 import re
 import random
 import decimal
@@ -354,6 +355,22 @@ class UltraJSONTests(TestCase):
         expected = calendar.timegm(tup)
         self.assertEquals(int(expected), json.loads(output))
         self.assertEquals(int(expected), ujson.decode(output))
+
+    def test_encodeWithTimezone(self):
+        start_timestamp = 1383647400
+        a = datetime.datetime.utcfromtimestamp(start_timestamp)
+
+        a = a.replace(tzinfo=pytz.utc)
+        b = a.astimezone(pytz.timezone('America/New_York'))
+        c = b.astimezone(pytz.utc)
+
+        d = {'a':a, 'b':b, 'c':c}
+        json_string = ujson.encode(d)
+        json_dict = ujson.decode(json_string)
+
+        self.assertEqual(json_dict.get('a'),start_timestamp)
+        self.assertEqual(json_dict.get('b'),start_timestamp)
+        self.assertEqual(json_dict.get('c'),start_timestamp)
 
     def test_encodeToUTF8(self):
         input = "\xe6\x97\xa5\xd1\x88"


### PR DESCRIPTION
This is a new pull request based on the conversation of issue #119

"Hi. First, thanks for ultrajson and ultramysql!

Problem

When given a UTC time and a timezoned version of the same value (e.g America/New_York) they give different values when "jsonified". They should give you the same epoch value.

Repro:

import datetime, pytz, ujson
a = datetime.datetime.utcfromtimestamp(1383647400)
a = a.replace(tzinfo=pytz.utc)
b = a.astimezone(pytz.timezone('America/New_York'))
c = b.astimezone(pytz.utc)
d = {'a':a, 'b':b, 'c':c}
ujson.dumps(d)

Result: (Notice 'b' is wrong)

'{"a":1383647400,"c":1383647400,"b":1383629400}'

Should be:

'{"a":1383647400,"c":1383647400,"b":1383647400}'
"
