### PR TITLE
If an object has a __json__ method, use it when encoding

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -154,6 +154,7 @@ enum JSTYPES
   JT_ULONG,     // (JSUINT64 (unsigned 64-bit))
   JT_DOUBLE,    // (double)
   JT_UTF8,      // (char 8-bit)
+  JT_RAW,       // (raw char 8-bit)
   JT_ARRAY,     // Array structure
   JT_OBJECT,    // Key/Value structure
   JT_INVALID,   // Internal, do not return nor expect

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -891,6 +891,28 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 
       Buffer_AppendCharUnchecked (enc, '\"');
       break;
+  }
+
+  case JT_RAW:
+  {
+      value = enc->getStringValue(obj, &tc, &szlen);
+      if(!value)
+      {
+        SetError(obj, enc, "utf-8 encoding error");
+        return;
+      }
+
+      Buffer_Reserve(enc, RESERVE_STRING(szlen));
+      if (enc->errorMsg)
+      {
+        enc->endTypeContext(obj, &tc);
+        return;
+      }
+
+      memcpy(enc->offset, value, szlen);
+      enc->offset += szlen;
+
+      break;
     }
   }
 


### PR DESCRIPTION
It should return a raw JSON string which will be directly included in the resulting JSON when encoding.

Similar to #130, but it allows an object to return already encoded string which is then included as it is in the output. This allows one to pass embed existing JSON strings inside a larger structure, without a need to deserialize and serialize again.
