### PR TITLE
Faster ascii encode

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -145,6 +145,7 @@ static void *PyStringToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, siz
 static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   PyObject *obj = (PyObject *) _obj;
+  PyObject *newObj;
 #if (PY_VERSION_HEX >= 0x03030000)
   if(PyUnicode_IS_COMPACT_ASCII(obj))
   {
@@ -154,7 +155,7 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, si
     return data;
   }
 #endif
-  PyObject *newObj = PyUnicode_EncodeUTF8 (PyUnicode_AS_UNICODE(obj), PyUnicode_GET_SIZE(obj), NULL);
+  newObj = PyUnicode_AsUTF8String(obj);
   if(!newObj)
   {
     return NULL;

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -145,6 +145,15 @@ static void *PyStringToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, siz
 static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   PyObject *obj = (PyObject *) _obj;
+#if (PY_VERSION_HEX >= 0x03030000)
+  if(PyUnicode_IS_COMPACT_ASCII(obj))
+  {
+    Py_ssize_t len;
+    char *data = PyUnicode_AsUTF8AndSize(obj, &len);
+    *_outLen = len;
+    return data;
+  }
+#endif
   PyObject *newObj = PyUnicode_EncodeUTF8 (PyUnicode_AS_UNICODE(obj), PyUnicode_GET_SIZE(obj), NULL);
   if(!newObj)
   {


### PR DESCRIPTION
PEP 393 introduces some string representation.
One of them is compact-ascii.  It contains only ASCII chars and provides zero-cost `PyUnicode_AsUTF8()` and `PyUnicode_AsUTF8AndSize()`.
Since most JSON keys are ASCII string, using it makes serialization faster.

Since other unicode representations creates utf-8 cache in PyUnicode_AsUTF8AndSize() and
it consume extra memory, I avoid using `PyUnicode_AsUTF8AndSize()` for them.

ref: http://methane.github.io/2014/12/fast-utf8-encode/

Before:

``` console
$ python3.4 -m timeit -n 10000 -s 'import ujson; x = ["a"*10]*100' 'ujson.dumps(x)'
10000 loops, best of 3: 15.8 usec per loop
```

After:

``` console
$ python3.4 -m timeit -n 10000 -s 'import ujson; x = ["a"*10]*100' 'ujson.dumps(x)'
10000 loops, best of 3: 7.14 usec per loop
```
