### PR TITLE
Sort keys

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -179,9 +179,12 @@ typedef void *(*JSPFN_MALLOC)(size_t size);
 typedef void (*JSPFN_FREE)(void *pptr);
 typedef void *(*JSPFN_REALLOC)(void *base, size_t size);
 
+
+struct __JSONObjectEncoder;
+
 typedef struct __JSONObjectEncoder
 {
-  void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc);
+  void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc, struct __JSONObjectEncoder *enc);
   void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
   JSINT64 (*getLongValue)(JSOBJ obj, JSONTypeContext *tc);
@@ -240,6 +243,10 @@ typedef struct __JSONObjectEncoder
   /*
   If true, '<', '>', and '&' characters will be encoded as \u003c, \u003e, and \u0026, respectively. If false, no special encoding will be used. */
   int encodeHTMLChars;
+
+  /*
+  If true, dictionaries are iterated through in sorted key order. */
+  int sortKeys;
 
   /*
   Private pointer to be used by the caller. Passed as encoder_prv in JSONTypeContext */

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -729,7 +729,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
     }
 
     tc.encoder_prv = enc->prv;
-    enc->beginTypeContext(obj, &tc);
+    enc->beginTypeContext(obj, &tc, enc);
 
     switch (tc.type)
     {

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -597,16 +597,16 @@ char *SortedDict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 void SetupDictIter(PyObject *dictObj, TypeContext *pc, JSONObjectEncoder *enc)
 {
   if (enc->sortKeys) {
-    pc->iterEnd = Dict_iterEnd;
-    pc->iterNext = Dict_iterNext;
-    pc->iterGetValue = Dict_iterGetValue;
-    pc->iterGetName = Dict_iterGetName;
-  }
-  else {
     pc->iterEnd = SortedDict_iterEnd;
     pc->iterNext = SortedDict_iterNext;
     pc->iterGetValue = SortedDict_iterGetValue;
     pc->iterGetName = SortedDict_iterGetName;
+  }
+  else {
+    pc->iterEnd = Dict_iterEnd;
+    pc->iterNext = Dict_iterNext;
+    pc->iterGetValue = Dict_iterGetValue;
+    pc->iterGetName = Dict_iterGetName;
   }
   pc->dictObj = dictObj;
   pc->index = 0;

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -483,18 +483,136 @@ char *Dict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
   return PyString_AS_STRING(GET_TC(tc)->itemName);
 }
 
-
-void SetupDictIter(PyObject *dictObj, TypeContext *pc)
+int SortedDict_iterNext(JSOBJ obj, JSONTypeContext *tc)
 {
-  pc->iterEnd = Dict_iterEnd;
-  pc->iterNext = Dict_iterNext;
-  pc->iterGetValue = Dict_iterGetValue;
-  pc->iterGetName = Dict_iterGetName;
+  PyObject *items = NULL, *item = NULL, *key = NULL, *value = NULL;
+  Py_ssize_t i, nitems;
+#if PY_MAJOR_VERSION >= 3
+  PyObject* keyTmp;
+#endif
+
+  // Upon first call, obtain a list of the keys and sort them. This follows the same logic as the
+  // stanard library's _json.c sort_keys handler.
+  if (GET_TC(tc)->newObj == NULL)
+  {
+    // Obtain the list of keys from the dictionary.
+    items = PyMapping_Keys(GET_TC(tc)->dictObj);
+    if (items == NULL)
+    {
+      goto error;
+    }
+    else if (!PyList_Check(items))
+    {
+      PyErr_SetString(PyExc_ValueError, "keys must return list");
+      goto error;
+    }
+
+    // Sort the list.
+    if (PyList_Sort(items) < 0)
+    {
+      goto error;
+    }
+
+    // Obtain the value for each key, and pack a list of (key, value) 2-tuples.
+    nitems = PyList_GET_SIZE(items);
+    for (i = 0; i < nitems; i++)
+    {
+      key = PyList_GET_ITEM(items, i);
+      value = PyDict_GetItem(GET_TC(tc)->dictObj, key);
+
+      // Subject the key to the same type restrictions and conversions as in Dict_iterGetValue.
+      if (PyUnicode_Check(key))
+      {
+        key = PyUnicode_AsUTF8String(key);
+      }
+      else if (!PyString_Check(key))
+      {
+        key = PyObject_Str(key);
+#if PY_MAJOR_VERSION >= 3
+        keyTmp = key;
+        key = PyUnicode_AsUTF8String(key);
+        Py_DECREF(keyTmp);
+#endif
+      }
+      else
+      {
+        Py_INCREF(key);
+      }
+
+      item = PyTuple_Pack(2, key, value);
+      if (item == NULL)
+      {
+        goto error;
+      }
+      PyList_SET_ITEM(items, i, item);
+      Py_DECREF(key);
+    }
+
+    // Store the sorted list of tuples in the newObj slot.
+    GET_TC(tc)->newObj = items;
+    GET_TC(tc)->size = nitems;
+  }
+
+  if (GET_TC(tc)->index >= GET_TC(tc)->size)
+  {
+    PRINTMARK();
+    return 0;
+  }
+
+  item = PyList_GET_ITEM(GET_TC(tc)->newObj, GET_TC(tc)->index);
+  GET_TC(tc)->itemName = PyTuple_GET_ITEM(item, 0);
+  GET_TC(tc)->itemValue = PyTuple_GET_ITEM(item, 1);
+  GET_TC(tc)->index++;
+  return 1;
+
+error:
+  Py_XDECREF(item);
+  Py_XDECREF(key);
+  Py_XDECREF(value);
+  Py_XDECREF(items);
+  return -1;
+}
+
+void SortedDict_iterEnd(JSOBJ obj, JSONTypeContext *tc)
+{
+  GET_TC(tc)->itemName = NULL;
+  GET_TC(tc)->itemValue = NULL;
+  Py_DECREF(GET_TC(tc)->newObj);
+  Py_DECREF(GET_TC(tc)->dictObj);
+  PRINTMARK();
+}
+
+JSOBJ SortedDict_iterGetValue(JSOBJ obj, JSONTypeContext *tc)
+{
+  return GET_TC(tc)->itemValue;
+}
+
+char *SortedDict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
+{
+  *outLen = PyString_GET_SIZE(GET_TC(tc)->itemName);
+  return PyString_AS_STRING(GET_TC(tc)->itemName);
+}
+
+
+void SetupDictIter(PyObject *dictObj, TypeContext *pc, JSONObjectEncoder *enc)
+{
+  if (enc->sortKeys) {
+    pc->iterEnd = Dict_iterEnd;
+    pc->iterNext = Dict_iterNext;
+    pc->iterGetValue = Dict_iterGetValue;
+    pc->iterGetName = Dict_iterGetName;
+  }
+  else {
+    pc->iterEnd = SortedDict_iterEnd;
+    pc->iterNext = SortedDict_iterNext;
+    pc->iterGetValue = SortedDict_iterGetValue;
+    pc->iterGetName = SortedDict_iterGetName;
+  }
   pc->dictObj = dictObj;
   pc->index = 0;
 }
 
-void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
+void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder *enc)
 {
   PyObject *obj, *exc, *toDictFunc, *iter;
   TypeContext *pc;
@@ -626,7 +744,7 @@ ISITERABLE:
   {
     PRINTMARK();
     tc->type = JT_OBJECT;
-    SetupDictIter(obj, pc);
+    SetupDictIter(obj, pc, enc);
     Py_INCREF(obj);
     return;
   }
@@ -698,7 +816,7 @@ ISITERABLE:
 
     PRINTMARK();
     tc->type = JT_OBJECT;
-    SetupDictIter(toDictResult, pc);
+    SetupDictIter(toDictResult, pc, enc);
     return;
   }
 
@@ -818,7 +936,7 @@ char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-  static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", "encode_html_chars", NULL};
+  static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", "encode_html_chars", "sort_keys", NULL};
 
   char buffer[65536];
   char *ret;
@@ -826,6 +944,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
   PyObject *oencodeHTMLChars = NULL;
+  PyObject *osortKeys = NULL;
 
   JSONObjectEncoder encoder =
   {
@@ -848,13 +967,14 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     10,  // default double precision setting
     1, //forceAscii
     0, //encodeHTMLChars
+    0, //sortKeys
     NULL, //prv
   };
 
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiO", kwlist, &oinput, &oensureAscii, &encoder.doublePrecision, &oencodeHTMLChars))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiOO", kwlist, &oinput, &oensureAscii, &encoder.doublePrecision, &oencodeHTMLChars, &osortKeys))
   {
     return NULL;
   }
@@ -867,6 +987,11 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   if (oencodeHTMLChars != NULL && PyObject_IsTrue(oencodeHTMLChars))
   {
     encoder.encodeHTMLChars = 1;
+  }
+
+  if (osortKeys != NULL && PyObject_IsTrue(osortKeys))
+  {
+    encoder.sortKeys = 1;
   }
 
   PRINTMARK();

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -41,6 +41,24 @@ def yajlEnc():
 
 """=========================================================================="""
 
+def ujsonEncSorted():
+    x = ujson.encode(testObject, ensure_ascii=False, sort_keys=True)
+    #print "ujsonEnc", x
+
+def simplejsonEncSorted():
+    x = simplejson.dumps(testObject, sort_keys=True)
+    #print "simplejsonEnc", x
+
+def jsonEncSorted():
+    x = json.dumps(testObject, sort_keys=True)
+    #print "jsonEnc", x
+
+def yajlEncSorted():
+    x = yajl.dumps(testObject, sort_keys=True)
+    #print "yaylEnc", x
+
+"""=========================================================================="""
+
 def ujsonDec():
     x = ujson.decode(decodeData)
     #print "ujsonDec: ", x
@@ -212,3 +230,8 @@ print "ujson decode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("ujsonD
 print "simplejson decode : %.05f calls/sec" % (COUNT / min(timeit.repeat("simplejsonDec()", "from __main__ import simplejsonDec", gettime,10, COUNT)), )
 print "yajl decode       : %.05f calls/sec" % (COUNT / min(timeit.repeat("yajlDec()", "from __main__ import yajlDec", gettime,10, COUNT)), )
 
+print "Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys:"
+
+print "ujson encode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("ujsonEncSorted()", "from __main__ import ujsonEncSorted", gettime,10, COUNT)), )
+print "simplejson encode : %.05f calls/sec" % (COUNT / min(timeit.repeat("simplejsonEncSorted()", "from __main__ import simplejsonEncSorted", gettime,10, COUNT)), )
+print "yajl  encode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("yajlEncSorted()", "from __main__ import yajlEncSorted", gettime, 10, COUNT)), )


### PR DESCRIPTION
This PR adds support for the `sort_keys` option during encoding. This partially addresses #82 and #90.

The benchmark results (see later) vary slightly before and after the patch simply due to runtime fluctuations. As the diff shows, there's no real overhead to this approach apart from the initial decision of which function pointers to use in `SetupDictIter` and passing the `JSONObjectEncoder` pointer to the `beginTypeContext` function.

Please double check my reference counting in the `SortedDict_*` functions. It looks okay to me but there's every chance I've buggered something up.

Benchmarking times are as follows. The first column is before the change and the second column is with this patch. There's an additional last section to include time comparisons for encodings with `sort_keys=True`.

```
Array with 256 doubles:
ujson encode      : 2871.82844 calls/sec     ujson encode      : 2982.04999 calls/sec
simplejson encode : 2863.41855 calls/sec     simplejson encode : 2882.71981 calls/sec
yajl  encode      : 2848.07388 calls/sec     yajl  encode      : 2874.05625 calls/sec
ujson decode      : 20740.72755 calls/sec    ujson decode      : 20721.18734 calls/sec
simplejson decode : 11235.04781 calls/sec    simplejson decode : 11132.68299 calls/sec
yajl decode       : 11233.48310 calls/sec    yajl decode       : 11127.12173 calls/sec

Array with 256 utf-8 strings:
ujson encode      : 3905.51099 calls/sec     ujson encode      : 3938.51886 calls/sec
simplejson encode : 1012.83972 calls/sec     simplejson encode : 1021.60910 calls/sec
yajl  encode      : 1012.81404 calls/sec     yajl  encode      : 1023.57455 calls/sec
ujson decode      : 1075.34800 calls/sec     ujson decode      : 1070.88166 calls/sec
simplejson decode : 295.93582 calls/sec      simplejson decode : 307.99879 calls/sec
yajl decode       : 296.64612 calls/sec      yajl decode       : 309.01055 calls/sec

Medium complex object
ujson encode      : 8900.67448 calls/sec     ujson encode      : 8903.14950 calls/sec
simplejson encode : 3132.81813 calls/sec     simplejson encode : 3219.91121 calls/sec
yajl  encode      : 3135.88930 calls/sec     yajl  encode      : 3219.33042 calls/sec
ujson decode      : 7414.63622 calls/sec     ujson decode      : 7415.12123 calls/sec
simplejson decode : 6338.50865 calls/sec     simplejson decode : 5973.10220 calls/sec
yajl decode       : 6349.41473 calls/sec     yajl decode       : 6051.24633 calls/sec

Array with 256 strings:
ujson encode      : 18711.09777 calls/sec    ujson encode      : 15970.51343 calls/sec
yajl  encode      : 10650.46681 calls/sec    yajl  encode      : 10802.68373 calls/sec
ujson decode      : 19126.99835 calls/sec    ujson decode      : 19112.97437 calls/sec
simplejson decode : 20340.58555 calls/sec    simplejson decode : 20555.74914 calls/sec
yajl decode       : 20380.54533 calls/sec    yajl decode       : 20609.16958 calls/sec

Array with 256 True values:
ujson encode      : 102485.87195 calls/sec   ujson encode      : 94199.06949 calls/sec
simplejson encode : 37812.30302 calls/sec    simplejson encode : 39491.38333 calls/sec
yajl  encode      : 37758.15968 calls/sec    yajl  encode      : 39407.19489 calls/sec
ujson decode      : 120721.90728 calls/sec   ujson decode      : 132191.16344 calls/sec
simplejson decode : 85027.93717 calls/sec    simplejson decode : 89647.66362 calls/sec
yajl decode       : 84529.45055 calls/sec    yajl decode       : 89352.56255 calls/sec

Array with 256 dict{string, int} pairs:
ujson encode      : 11211.84467 calls/sec    ujson encode      : 11326.99924 calls/sec
simplejson encode : 3332.76017 calls/sec     simplejson encode : 3240.11531 calls/sec
yajl  encode      : 3326.95013 calls/sec     yajl  encode      : 3236.30423 calls/sec
ujson decode      : 13512.27260 calls/sec    ujson decode      : 13698.73716 calls/sec
simplejson decode : 9680.89968 calls/sec     simplejson decode : 9737.30678 calls/sec
yajl decode       : 9667.49812 calls/sec     yajl decode       : 9748.14696 calls/sec

Dict with 256 arrays with 256 dict{string, int} pairs:
ujson encode      : 41.71001 calls/sec       ujson encode      : 42.31235 calls/sec
simplejson encode : 10.87917 calls/sec       simplejson encode : 10.75588 calls/sec
yajl  encode      : 10.91323 calls/sec       yajl  encode      : 10.73039 calls/sec
ujson decode      : 27.23097 calls/sec       ujson decode      : 27.42404 calls/sec
simplejson decode : 20.57137 calls/sec       simplejson decode : 21.10473 calls/sec
yajl decode       : 20.56969 calls/sec       yajl decode       : 21.05428 calls/sec

Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys:
                                             ujson encode      : 22.21406 calls/sec
                                             simplejson encode : 6.73193 calls/sec
                                             yajl  encode      : 6.70632 calls/sec
```
