### PR TITLE
Support for space indent for JSON encoding

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -242,6 +242,10 @@ typedef struct __JSONObjectEncoder
   int encodeHTMLChars;
 
   /*
+  Configuration for spaces of indent */
+  int indent;
+
+  /*
   Private pointer to be used by the caller. Passed as encoder_prv in JSONTypeContext */
   void *prv;
 

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -478,6 +478,20 @@ FASTCALL_ATTR INLINE_PREFIX void FASTCALL_MSVC strreverse(char* begin, char* end
   aux = *end, *end-- = *begin, *begin++ = aux;
 }
 
+void Buffer_AppendIndentNewlineUnchecked(JSONObjectEncoder *enc)
+{
+  if (enc->indent > 0) Buffer_AppendCharUnchecked(enc, '\n');
+}
+
+void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value)
+{
+  int i;
+  if (enc->indent > 0)
+    while (value-- > 0)
+      for (i = 0; i < enc->indent; i++)
+        Buffer_AppendCharUnchecked(enc, ' ');
+}
+
 void Buffer_AppendIntUnchecked(JSONObjectEncoder *enc, JSINT32 value)
 {
   char* wstr;
@@ -743,6 +757,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
         count = 0;
 
         Buffer_AppendCharUnchecked (enc, '[');
+        Buffer_AppendIndentNewlineUnchecked (enc);
 
         while (enc->iterNext(obj, &tc))
         {
@@ -752,16 +767,20 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 #ifndef JSON_NO_EXTRA_WHITESPACE
             Buffer_AppendCharUnchecked (buffer, ' ');
 #endif
+            Buffer_AppendIndentNewlineUnchecked (enc);
           }
 
           iterObj = enc->iterGetValue(obj, &tc);
 
           enc->level ++;
+          Buffer_AppendIndentUnchecked (enc, enc->level);
           encode (iterObj, enc, NULL, 0);
           count ++;
       }
 
       enc->iterEnd(obj, &tc);
+      Buffer_AppendIndentNewlineUnchecked (enc);
+      Buffer_AppendIndentUnchecked (enc, enc->level);
       Buffer_AppendCharUnchecked (enc, ']');
       break;
   }
@@ -771,6 +790,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
     count = 0;
 
     Buffer_AppendCharUnchecked (enc, '{');
+    Buffer_AppendIndentNewlineUnchecked (enc);
 
     while (enc->iterNext(obj, &tc))
     {
@@ -780,17 +800,21 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 #ifndef JSON_NO_EXTRA_WHITESPACE
         Buffer_AppendCharUnchecked (enc, ' ');
 #endif
+        Buffer_AppendIndentNewlineUnchecked (enc);
       }
 
       iterObj = enc->iterGetValue(obj, &tc);
       objName = enc->iterGetName(obj, &tc, &szlen);
 
       enc->level ++;
+      Buffer_AppendIndentUnchecked (enc, enc->level);
       encode (iterObj, enc, objName, szlen);
       count ++;
     }
 
     enc->iterEnd(obj, &tc);
+    Buffer_AppendIndentNewlineUnchecked (enc);
+    Buffer_AppendIndentUnchecked (enc, enc->level);
     Buffer_AppendCharUnchecked (enc, '}');
     break;
   }

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -818,7 +818,7 @@ char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-  static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", "encode_html_chars", NULL};
+  static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", "encode_html_chars", "indent", NULL};
 
   char buffer[65536];
   char *ret;
@@ -848,13 +848,14 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     10,  // default double precision setting
     1, //forceAscii
     0, //encodeHTMLChars
+    0, //indent
     NULL, //prv
   };
 
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiO", kwlist, &oinput, &oensureAscii, &encoder.doublePrecision, &oencodeHTMLChars))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiOi", kwlist, &oinput, &oensureAscii, &encoder.doublePrecision, &oencodeHTMLChars, &encoder.indent))
   {
     return NULL;
   }


### PR DESCRIPTION
This PR is to resolve #162, "support indent like built-in json"
