### PR TITLE
Support __json__ as an alternative to toDict (it's a bit more Pythonic)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,14 @@ Controls whether indention ("pretty output") is enabled. Default is 0 (disabled)
         "foo":"bar"
     }
 
+encode_date
+-------------
+
+Supply a custom function to encode a date. Will be encoded as as string::
+
+    >>> ujson.dumps(datetime.utcnow(), encode_date=lambda d: d.strftime('%d-%m-%y'))
+    '"25-04-15"'
+
 ~~~~~~~~~~~~~~~~
 Decoders options
 ~~~~~~~~~~~~~~~~    

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -53,6 +53,7 @@ tree doesn't have cyclic references.
 #ifndef __ULTRAJSON_H__
 #define __ULTRAJSON_H__
 
+#include "py_defines.h"
 #include <stdio.h>
 #include <wchar.h>
 
@@ -167,6 +168,7 @@ typedef struct __JSONTypeContext
   int type;
   void *prv;
   void *encoder_prv;
+  void *encoder;
 } JSONTypeContext;
 
 /*
@@ -256,6 +258,10 @@ typedef struct __JSONObjectEncoder
   /*
   Configuration for spaces of indent */
   int indent;
+
+  /*
+  Configuration for a function that can encode a date */
+  PyObject *encodeDate;
 
   /*
   Private pointer to be used by the caller. Passed as encoder_prv in JSONTypeContext */

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -763,6 +763,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
     }
 
     tc.encoder_prv = enc->prv;
+    tc.encoder = enc;
     enc->beginTypeContext(obj, &tc, enc);
 
     switch (tc.type)

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -785,11 +785,13 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder
 ISITERABLE:
   if (PyDict_Check(obj))
   {
-    PRINTMARK();
-    tc->type = JT_OBJECT;
-    SetupDictIter(obj, pc, enc);
-    Py_INCREF(obj);
-    return;
+    if(!PyObject_HasAttrString(obj, "__json__") && !PyObject_HasAttrString(obj, "toDict")) {
+      PRINTMARK();
+      tc->type = JT_OBJECT;
+      SetupDictIter(obj, pc, enc);
+      Py_INCREF(obj);
+      return;
+    }
   }
   else
   if (PyList_Check(obj))

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -801,7 +801,10 @@ ISITERABLE:
   }
   */
 
-  toDictFunc = PyObject_GetAttrString(obj, "toDict");
+  if(PyObject_HasAttrString(obj, "__json__"))
+      toDictFunc = PyObject_GetAttrString(obj, "__json__");
+  else
+      toDictFunc = PyObject_GetAttrString(obj, "toDict");
 
   if (toDictFunc)
   {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -242,12 +242,12 @@ class UltraJSONTests(unittest.TestCase):
         s = u'\U0001f42e\U0001f42e\U0001F42D\U0001F42D' # 🐮🐮🐭🐭
         encoded = ujson.dumps(s)
         encoded_json = json.dumps(s)
-		
+
         if len(s) == 4:
             self.assertEqual(len(encoded), len(s) * 12 + 2)
         else:
-            self.assertEqual(len(encoded), len(s) * 6 + 2) 
-          
+            self.assertEqual(len(encoded), len(s) * 6 + 2)
+
         self.assertEqual(encoded, encoded_json)
         decoded = ujson.loads(encoded)
         self.assertEqual(s, decoded)
@@ -839,6 +839,14 @@ class UltraJSONTests(unittest.TestCase):
         dec = ujson.decode(output)
         self.assertEqual(dec, d)
 
+    def test_sepcial__json__(self):
+        class TestObj:
+            def __json__(self):
+                return {'hello_new': 'world_new'}
+
+        json = ujson.encode(TestObj())
+        self.assertEqual(json, '{"hello_new":"world_new"}')
+
     def test_decodeArrayTrailingCommaFail(self):
         input = "[31337,]"
         try:
@@ -1064,6 +1072,7 @@ class UltraJSONTests(unittest.TestCase):
         data = {"a": 1, "c": 1, "b": 1, "e": 1, "f": 1, "d": 1}
         sortedKeys = ujson.dumps(data, sort_keys=True)
         self.assertEqual(sortedKeys, '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1}')
+
 
 """
 def test_decodeNumericIntFrcOverflow(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -373,6 +373,15 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(int(expected), json.loads(output))
         self.assertEqual(int(expected), ujson.decode(output))
 
+    def test_customDateEncoder(self):
+        def custom_date_encode(date):
+            return date.strftime('%d/%m/%y')
+
+        input = datetime.date(2015, 1, 1)
+        output = ujson.encode(input,
+                              encode_date=custom_date_encode)
+        self.assertEqual(output, '"01\\/01\\/15"')
+
     def test_encodeToUTF8(self):
         input = "\xe6\x97\xa5\xd1\x88"
         enc = ujson.encode(input, ensure_ascii=False)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -849,12 +849,15 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(dec, d)
 
     def test_sepcial__json__(self):
-        class TestObj:
+        class TestObj(dict):
             def __json__(self):
                 return {'hello_new': 'world_new'}
 
         json = ujson.encode(TestObj())
         self.assertEqual(json, '{"hello_new":"world_new"}')
+
+        json_list = ujson.encode([TestObj()])
+        self.assertEqual(json_list, '[{"hello_new":"world_new"}]')
 
     def test_decodeArrayTrailingCommaFail(self):
         input = "[31337,]"


### PR DESCRIPTION
I see there are different notions what **json** should return.

Here's an alternative that makes it work like toDict. I think this makes sense since **json** can be seen just as a JSON representation of the object (that's not yet serialized).

We use this to only expose some fields of objects when we export them to JSON.
