### PR TITLE
escape_forward_slashes now only ignores forward slashes, not everythi…

### DIFF
--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -433,6 +433,12 @@ int Buffer_EscapeStringValidated (JSOBJ obj, JSONObjectEncoder *enc, const char 
       case 18:
       case 20:
       case 22:
+      {
+        *(of++) = *( (char *) (g_escapeChars + utflen + 0));
+        *(of++) = *( (char *) (g_escapeChars + utflen + 1));
+        io ++;
+        continue;
+      }
       case 24:
       {
         if (enc->escapeForwardSlashes)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -49,7 +49,7 @@ class UltraJSONTests(unittest.TestCase):
         input = "A string \\ / \b \f \n \r \t </script> &"
         not_html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t <\\/script> &"'
         html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t \\u003c\\/script\\u003e \\u0026"'
-        not_slashes_escaped = input
+        not_slashes_escaped = '"A string \\\\ / \\b \\f \\n \\r \\t </script> &"'
 
         def helper(expected_output, **encode_kwargs):
             output = ujson.encode(input, **encode_kwargs)


### PR DESCRIPTION
…ng else
This rendered escaping completely broken for escape_forward_slashes=False
