### PR TITLE
Check if object has __slots__ and use them before calling dir()

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -624,7 +624,7 @@ void SetupDictIter(PyObject *dictObj, TypeContext *pc, JSONObjectEncoder *enc)
 
 void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder *enc)
 {
-  PyObject *obj, *exc, *toDictFunc, *iter;
+  PyObject *obj, *exc, *toDictFunc, *iter, *attrList;
   TypeContext *pc;
   PRINTMARK();
   if (!_obj) {
@@ -852,14 +852,18 @@ ISITERABLE:
 
   PRINTMARK();
   tc->type = JT_OBJECT;
-  GET_TC(tc)->attrList = PyObject_Dir(obj);
-  
-  if (GET_TC(tc)->attrList == NULL)
+  attrList = PyObject_GetAttrString(obj, "__slots__");
+  if (attrList == NULL) {
+    PyErr_Clear();
+    attrList = PyObject_Dir(obj);
+  }
+
+  if (attrList == NULL)
   {
     PyErr_Clear();
     goto INVALID;
   }
-
+  GET_TC(tc)->attrList = attrList;
   GET_TC(tc)->index = 0;
   GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
   PRINTMARK();


### PR DESCRIPTION
Hi.
Accidentally found that `ujson` can encode arbitrary Python objects. I thought maybe using `__slots__`  as object keys can be more intuitive and useful.
Our particular use case is dumping Thrift objects (generated with `py:slots`) without first transforming then into dictionaries. These objects have `thrift_spec` and other attributes that we don't want to see in JSON.
