### PR TITLE
Corrected memory leak in sort_keys=True

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -554,7 +554,10 @@ int SortedDict_iterNext(JSOBJ obj, JSONTypeContext *tc)
       {
         goto error;
       }
-      PyList_SET_ITEM(items, i, item);
+      if (PyList_SetItem(items, i, item))
+      {
+        goto error;
+      }
       Py_DECREF(key);
     }
 


### PR DESCRIPTION
In my implementation of support for `sort_keys=True` to JSON serialisation (#161), I accidentally introduced a memory leak due to not decrementing the reference count of the object being replaced in a list. My bad :( This pull request fixes this memory leak.
