### PR TITLE
do not forcefully remove the build directory manually (fix #179)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
   from distutils.core import setup, Extension
 import distutils.sysconfig
-import shutil
 import os.path
 import re
 import sys
@@ -21,11 +20,6 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.2
 """.splitlines()))
-
-try:
-    shutil.rmtree("./build")
-except(OSError):
-    pass
 
 module1 = Extension('ujson',
                     sources = ['./python/ujson.c', 


### PR DESCRIPTION
this fixes issue #179.
setuptools should itself know when to use cache or create a
new build... however if someone wants to override that, it's
still possible but forcefully doing that on whatever
setuptools target will (and does) introduce problems.

Build directory should be cleaned up via the clean sub-command.
examples:
- clean up temp:
  python setup.py clean
- clean up whole build dir
  python setup.py clean -a

Or if somebody wants to, the build dir could be removed on the
shell.
