### PR TITLE
implement encode/decode hooks that allow to define custom serialization formats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,19 @@ For example, if you return a `datetime` object from the hook instead of a string
 it will be transformed to a timestamp.
 
 
+pre_encode_primitive
+---------------
+The boolean flag that indicates that pre_encode_hook() should also be called
+for Python objects that serialized to primitive JSON types (Number, String,
+Boolean, null).
+
+Usually you don't need to define any special serialization format for these
+types, so the flag is false by default.
+
+Enabling this flag may produce huge amount of pre_encode_hook() calls (the
+hook will be called for every single JSON value) and thus affect the performance.
+
+
 ~~~~~~~~~~~~~~~~
 Decoders options
 ~~~~~~~~~~~~~~~~

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -185,6 +185,7 @@ struct __JSONObjectEncoder;
 
 typedef struct __JSONObjectEncoder
 {
+  JSOBJ (*callPreEncodeHook)(JSOBJ obj, struct __JSONObjectEncoder *enc);
   void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc, struct __JSONObjectEncoder *enc);
   void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
@@ -313,6 +314,7 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newLong)(void *prv, JSINT64 value);
   JSOBJ (*newUnsignedLong)(void *prv, JSUINT64 value);
   JSOBJ (*newDouble)(void *prv, double value);
+  JSOBJ (*callObjectHook)(JSOBJ obj, void *prv);
   void (*releaseObject)(void *prv, JSOBJ obj);
   JSPFN_MALLOC malloc;
   JSPFN_FREE free;

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -185,7 +185,15 @@ struct __JSONObjectEncoder;
 
 typedef struct __JSONObjectEncoder
 {
+  /*
+   The pre-encode hook is called for each object, right before the beginTypeContext().
+   Its purpose is to allow to define an arbitrary serialization format by replacing objects on the fly during the encoding process.
+   So this hook takes an object (which is being encoded), and returns a new object.
+   After the hook is executed, the caller must completely forget the old object (since it may be already deallocated by the hook),
+   and use only the new object returned by this hook. The new object is also passed then to the beginTypeContext().
+   */
   JSOBJ (*callPreEncodeHook)(JSOBJ obj, struct __JSONObjectEncoder *enc);
+  
   void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc, struct __JSONObjectEncoder *enc);
   void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
@@ -314,7 +322,15 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newLong)(void *prv, JSINT64 value);
   JSOBJ (*newUnsignedLong)(void *prv, JSUINT64 value);
   JSOBJ (*newDouble)(void *prv, double value);
+  
+  /*
+   * The callObjectHook() is executed after a whole JSON object (the thing surrounded by curly {} braces) is decoded.
+   * Its purpose is to transform generic hash-like objects into more specific entities defined by the user (structures, classes, etc).
+   * The hook takes the decoded obj, and returns a new object.
+   * After the hook is executed, the caller should use only the new returned object, and completely forget the old object (since the old object may be deallocated by the hook).
+   */
   JSOBJ (*callObjectHook)(JSOBJ obj, void *prv);
+  
   void (*releaseObject)(void *prv, JSOBJ obj);
   JSPFN_MALLOC malloc;
   JSPFN_FREE free;

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -807,6 +807,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_object( struct DecoderState *ds)
       case '}':
       {
         ds->objDepth--;
+        newObj = ds->dec->callObjectHook(newObj, ds->prv);
         return newObj;
       }
       case ',':

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -807,7 +807,11 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_object( struct DecoderState *ds)
       case '}':
       {
         ds->objDepth--;
-        newObj = ds->dec->callObjectHook(newObj, ds->prv);
+
+        if (ds->dec->callObjectHook)
+          /* Note: the hook may return NULL (and thus signal an error). */
+          newObj = ds->dec->callObjectHook(newObj, ds->prv);
+
         return newObj;
       }
       case ',':

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -769,6 +769,8 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 #endif
     }
 
+    obj = enc->callPreEncodeHook(obj, enc);
+
     tc.encoder_prv = enc->prv;
     enc->beginTypeContext(obj, &tc, enc);
 

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -769,7 +769,16 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 #endif
     }
 
-    obj = enc->callPreEncodeHook(obj, enc);
+    if (enc->callPreEncodeHook) {
+      JSOBJ newobj = enc->callPreEncodeHook(obj, enc);
+
+      if (!newobj) {
+        SetError(obj, enc, "error signalled by the pre-encode hook");
+        return;
+      }
+
+      obj = newobj;
+    }
 
     tc.encoder_prv = enc->prv;
     enc->beginTypeContext(obj, &tc, enc);

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -150,9 +150,6 @@ JSOBJ Object_callObjectHook(JSOBJ _obj, void *prv)
   PyObject *obj, *newobj;
   DecoderParams *dp = prv;
 
-  if (!dp->objectHook)
-    return _obj;
-
   obj = (PyObject *)_obj;
   newobj = PyObject_CallFunctionObjArgs(dp->objectHook, obj, NULL);
 
@@ -192,7 +189,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newLong,
     Object_newUnsignedLong,
     Object_newDouble,
-    Object_callObjectHook,
+    NULL, //callObjectHook (optional, initialized below if passed as the keyword parameter)
     Object_releaseObject,
     PyObject_Malloc,
     PyObject_Free,
@@ -219,6 +216,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
 
   if (oobjectHook && PyCallable_Check(oobjectHook))
   {
+    decoder.callObjectHook = Object_callObjectHook;
     dp.objectHook = oobjectHook;
   }
 

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -39,11 +39,29 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include "py_defines.h"
 #include <ultrajson.h>
 
-
+/*
+ * The DecoderParams contains some Python-specific decoder parameters.
+ * It is accessible via the JSONObjectDecoder->prv field.
+ */
 typedef struct __DecoderParams
 {
+  /*
+   * These hooks are Python functions (callable objects) provided by the user
+   * via keyword parameters of JSONToObj(). They allow to decode JSON entities
+   * into specific Python class instances (instead of generic dictionaries
+   * and strings).
+   *
+   * The objectHook is called when a JSON object is decoded. It takes the object
+   * (as dictionary) and may transform it into an arbitrary object (instanciate
+   * a class, etc).
+   *
+   * The stringHook is called for every decoded string. It may replace the string
+   * with an arbitrary object. Useful for deserializing things like dates from
+   * their textual representations into native Python types.
+   */
   PyObject *objectHook;
   PyObject *stringHook;
+
 } DecoderParams;
 
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -76,8 +76,24 @@ typedef struct __TypeContext
 
 #define GET_TC(__ptrtc) ((TypeContext *)((__ptrtc)->prv))
 
+/*
+ * The EncoderParams contains some private Python-specific encoder parameters.
+ * It is accessible via the JSONObjectEncoder->prv field,
+ * or via the GET_EP() macro.
+ */
 typedef struct __EncoderParams
 {
+  /*
+   * The preEncodeHook is a Python function (callable object) provided by the
+   * user via the corresponding keyword parameter for objToJSON() function.
+   *
+   * The hook is called for every encoded Python object. It may replace the
+   * object with another object (a more generic one, like dictionary or list or
+   * string) and thus define a custom serialization format.
+   *
+   * This is useful for serializing objects when you don't own their source code
+   * and can't implement a __json__() or toDict() method (e.g., datetime objects).
+   */
   PyObject *preEncodeHook;
 } EncoderParams;
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,6 +28,12 @@ json_unicode = json.dumps if six.PY3 else functools.partial(json.dumps, encoding
 
 class UltraJSONTests(unittest.TestCase):
     def test_hooks_representDatetimeAsString(self):
+        # In this test, we define a custom JSON representation for datetime objects.
+        # Here they are represented as strings. E.g., "1990-01-01 00:00:00".
+        
+        # Note that this also overrides the default ujson's behavior
+        # (the ujson translates datetime objects into timestamps).
+        
         dt_fmt = '__DT: %Y-%m-%d %H:%M:%S'
         
         def enchook_dtAsStr(obj_being_encoded):
@@ -52,6 +58,13 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(input, decoded_obj)
     
     def test_hooks_representDatetimeAsJsObject(self):
+        # In this test, datetime objects are split into components and represented
+        # as hash-like JSON objects.
+        #
+        # The enchook_dtAsObj() replaces a datetime object with a dictionary,
+        # and the dechook_dtFromObj() does the reverse by passing the dictionary
+        # as keyword parameters to the datetime() constructor.
+        
         def enchook_dtAsObj(obj_being_encoded):
             if isinstance(obj_being_encoded, datetime.datetime):
                 dt = obj_being_encoded

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -48,7 +48,7 @@ class UltraJSONTests(unittest.TestCase):
          
         input = {
             'a': 'dummy',
-            'b': datetime.datetime(2016, 02, 03, 02, 31, 01),
+            'b': datetime.datetime(2016, 2, 3, 2, 31, 1),
         }
         expected_json = '{"a":"dummy","b":"__DT: 2016-02-03 02:31:01"}'
         encoded_json = ujson.encode(input, sort_keys=True, pre_encode_hook=enchook_dtAsStr)
@@ -89,7 +89,7 @@ class UltraJSONTests(unittest.TestCase):
         
         input = {
             'a': 'dummy',
-            'b': datetime.datetime(2016, 02, 03, 02, 31, 01)
+            'b': datetime.datetime(2016, 2, 3, 2, 31, 1)
         }
         expected_json = """
         {


### PR DESCRIPTION
This pull request proposes encoding/decoding hooks, that is,custom Python functions that you may pass to `ujson.encode()`/`ujson.decode()` and transform objects on the fly during the encoding/decoding process.

Basically this is a customization feature. Especially useful to override certain behavior already implemented by the ujson code, like `datetime` serialization or `__json__()` method handling (see below).

The hook behavior is similar to `json.dumps(default=fn)` and `json.loads(object_hook=fn)` semantics, you just pass a function that takes an object and possibly replaces it with another object. But unlike the `default` hook (that is called at the end) I implemented the `pre_encode_hook` (that is called before any other transformations are made), and this is done intentionally to allow user to override certain ujson's behavior inside the hook.

See the `README.rst` and `tests.py` for usage examples.

Motivation:
- Customization features are demanded for long time, see #124, #139.
  
  People are making their own forks and do minor changes in the C code to customize serialization for various types. That should be solved by extending the Python API.
  
  Hooks may be a good tradeoff solution (not as good as an object-oriented API where you can override methods and so on, but still ok).
- The current ujson's implementation translates `date` and `datetime` objects into timestamps, and there is no option for switching to another format (like ISO 8601).
  
  Actually the format is not defined by JSON, so any hardcoded implementation is doomed.
  
  I guess the pull request #201 is related here: it defines another hard-coded format, so it doesn't solve this problem, but still may be useful as a performance optimization for this specific format.
- The `__json__()` method also has a problem: ujson expects this method to return a string containing valid JSON, while the usual approach (or at least how I know it) is to return an object like a dictionary from the `__json__()` method. 
  
  Recently I had noticeable issues because of that when I tried to switch to ujson on one of projects. And the `toDict()` method is not always the solution, since you don't always return a dictionary. And I think generally the ujson should try to be compatible with already existing code (ideally, a drop-in replacement), so there should be an option for changing the `__json__()` semantics without changing tons of ORM classes that implement this method.
  
  And if you change the ujson's behavior to this "usual" approach, you will break the backwards compatibility. Again, there is no standard option here, so it would be better to let people to override this behavior with an arbitrary implementation.

So, now I'm asking someone to review the changes and make some comments.
Especially pay some attention to reference counting, I'm not sure that I handled it correctly.

Thanks!
