### PR TITLE
Failing test about split multibyte character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install six blist unittest2 pytz
+  - pip install six blist unittest2 pytz mock
   - python setup.py install
 script: python tests/tests.py

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,6 +11,7 @@ import json
 import math
 import time
 import pytz
+import mock
 if six.PY2:
     import unittest2 as unittest
 else:
@@ -920,6 +921,26 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_WriteArrayOfSymbolsFromTuple(self):
         self.assertEqual("[true,false,null]", ujson.dumps((True, False, None)))
+
+    def test_load_with_split_unicode(self):
+        # These together produce JSON-encoded 'ü'
+        first, second = '"\\u00', 'fc"'
+        self.assertEqual('ü', ujson.loads(first + second))
+
+        # This is the content split over two successive reads
+        fin = mock.MagicMock()
+        fin.read.side_effect = [first, second]
+        self.assertEqual('ü', ujson.load(fin))
+
+    def test_load_with_split_utf8(self):
+        # These together produce JSON-encoded 'ü'
+        first, second = '"\xC3', '\xBC"'
+        self.assertEqual('ü', ujson.loads(first + second))
+
+        # This is the content split over two successive reads
+        fin = mock.MagicMock()
+        fin.read.side_effect = [first, second]
+        self.assertEqual('ü', ujson.load(fin))
 
     @unittest.skipIf(not six.PY3, "Only raises on Python 3")
     def test_encodingInvalidUnicodeCharacter(self):


### PR DESCRIPTION
When streaming JSON from a file-like object, it's possible for two successive reads to happen to split a multibyte character. In that case, remaining bytes must be read before attempting to interpret the sequence correctly.

For example, `ü` is encoded as `\u00fc`. If `\u00` should appear in one read, and the `fc` in the next, the current implementation attempts to interpret `\u00`, throwing an exception:

`ValueError: Unexpected character in unicode escape sequence when decoding 'string'`

@vadim-moz mentioned this is a problem in some JSON implementations, which spurred my curiosity. Also, @benkirzhner, @sistawendy, and @b4hand may be interested.
