### PR TITLE
Force inlining of the inline functions

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -115,7 +115,11 @@ typedef uint32_t JSUINT32;
 #define FASTCALL_ATTR
 #endif
 
+#ifdef __GNUC__
+#define INLINE_PREFIX __attribute__((always_inline)) inline
+#else
 #define INLINE_PREFIX inline
+#endif
 
 typedef uint8_t JSUINT8;
 typedef uint16_t JSUTF16;


### PR DESCRIPTION
`inline` is not a requirement but only a suggestion, hence the compiler
has the freedom to not really compile the marked functions as inline.
Under some situations the affected functions could end up undefined in
the compiled library, causing its loading to fail!

For GCC at least, adding an `always_inline` attribute is enough to force
inlining. Not sure if this breaks other compilers but I cannot test, so
the definition is guarded by a check for GCC.

Really fixes #180, which is also a problem on, at least, Gentoo with GCC
5.3.0.

Evidence:

```
(before)
$ nm ujson.gcc-4.9.3.so | grep 'strreverse\|Buffer_AppendShortHex'
0000000000007557 T Buffer_AppendShortHexUnchecked
0000000000007557 t Buffer_AppendShortHexUnchecked.localalias.1
000000000000805d T strreverse
000000000000805d t strreverse.localalias.0

$ nm ujson.gcc-5.3.0.so | grep 'strreverse\|Buffer_AppendShortHex'
                 U Buffer_AppendShortHexUnchecked
                 U strreverse

(after)
$ nm ujson.gcc-5.3.0-always_inline.so | grep 'strreverse\|Buffer_AppendShortHex'
(no output)
```
