### PR TITLE
Fix OverflowError when encoding numpy arrays

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -1,5 +1,5 @@
 /*
-Developed by ESN, an Electronic Arts Inc. studio. 
+Developed by ESN, an Electronic Arts Inc. studio.
 Copyright (c) 2014, Electronic Arts Inc.
 All rights reserved.
 
@@ -17,7 +17,7 @@ derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS INC. BE LIABLE 
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS INC. BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
@@ -119,17 +119,13 @@ static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_
 
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
-  /**((JSINT64 *) outValue) = GET_TC(tc)->longValue;*/
-  PyObject *obj = (PyObject *) _obj;
-  *((JSINT64 *) outValue) = PyInt_AS_LONG (PyNumber_Long(obj));
+  *((JSINT64 *) outValue) = GET_TC(tc)->longValue;
   return NULL;
 }
 
 static void *PyLongToUINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
-  /**((JSUINT64 *) outValue) = GET_TC(tc)->unsignedLongValue;*/
-  PyObject *obj = (PyObject *) _obj;
-  *((JSINT64 *) outValue) = PyInt_AS_LONG (PyNumber_Long(obj));
+  *((JSUINT64 *) outValue) = GET_TC(tc)->unsignedLongValue;
   return NULL;
 }
 
@@ -907,7 +903,7 @@ ISITERABLE:
   PRINTMARK();
   tc->type = JT_OBJECT;
   GET_TC(tc)->attrList = PyObject_Dir(obj);
-  
+
   if (GET_TC(tc)->attrList == NULL)
   {
     PyErr_Clear();
@@ -917,7 +913,7 @@ ISITERABLE:
   GET_TC(tc)->index = 0;
   GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
   PRINTMARK();
-  
+
   pc->iterEnd = Dir_iterEnd;
   pc->iterNext = Dir_iterNext;
   pc->iterGetValue = Dir_iterGetValue;

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -686,7 +686,14 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder
     return;
   }
   else
-  if (PyNumber_Check(obj) && PyNumber_Long(obj) && !PyFloat_Check(obj)){
+  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)))
+  {
+    PRINTMARK();
+    pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;
+    return;
+  }
+  else
+  if (PyNumber_Check(obj) && PyNumber_Long(obj)){
     PRINTMARK();
     pc->PyTypeToJSON = PyLongToINT64;
     tc->type = JT_LONG;
@@ -738,13 +745,6 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder
   {
     PRINTMARK();
     pc->PyTypeToJSON = PyUnicodeToUTF8; tc->type = JT_UTF8;
-    return;
-  }
-  else
-  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)))
-  {
-    PRINTMARK();
-    pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;
     return;
   }
   else

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -119,13 +119,17 @@ static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_
 
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
-  *((JSINT64 *) outValue) = GET_TC(tc)->longValue;
+  /**((JSINT64 *) outValue) = GET_TC(tc)->longValue;*/
+  PyObject *obj = (PyObject *) _obj;
+  *((JSINT64 *) outValue) = PyInt_AS_LONG (PyNumber_Long(obj));
   return NULL;
 }
 
 static void *PyLongToUINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
-  *((JSUINT64 *) outValue) = GET_TC(tc)->unsignedLongValue;
+  /**((JSUINT64 *) outValue) = GET_TC(tc)->unsignedLongValue;*/
+  PyObject *obj = (PyObject *) _obj;
+  *((JSINT64 *) outValue) = PyInt_AS_LONG (PyNumber_Long(obj));
   return NULL;
 }
 
@@ -686,12 +690,11 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder
     return;
   }
   else
-  if (PyLong_Check(obj))
-  {
+  if (PyNumber_Check(obj) && PyNumber_Long(obj) && !PyFloat_Check(obj)){
     PRINTMARK();
     pc->PyTypeToJSON = PyLongToINT64;
     tc->type = JT_LONG;
-    GET_TC(tc)->longValue = PyLong_AsLongLong(obj);
+    GET_TC(tc)->longValue = PyLong_AsLongLong(PyNumber_Long(obj));
 
     exc = PyErr_Occurred();
     if (!exc)
@@ -704,7 +707,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObjectEncoder
       PyErr_Clear();
       pc->PyTypeToJSON = PyLongToUINT64;
       tc->type = JT_ULONG;
-      GET_TC(tc)->unsignedLongValue = PyLong_AsUnsignedLongLong(obj);
+      GET_TC(tc)->unsignedLongValue = PyLong_AsUnsignedLongLong(PyNumber_Long(obj));
 
       exc = PyErr_Occurred();
       if (exc && PyErr_ExceptionMatches(PyExc_OverflowError))
@@ -1025,7 +1028,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     PyObject_Malloc,
     PyObject_Realloc,
     PyObject_Free,
-    -1, //recursionMax
+    0, //recursionMax
     10,  // default double precision setting
     1, //forceAscii
     0, //encodeHTMLChars

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -410,7 +410,7 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_encodeDoubleNan(self):
         input = float('nan')
-        self.assertRaises(OverflowError, ujson.encode, input)
+        self.assertRaises(ValueError, ujson.encode, input)
 
     def test_encodeDoubleInf(self):
         input = float('inf')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -410,7 +410,7 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_encodeDoubleNan(self):
         input = float('nan')
-        self.assertRaises(ValueError, ujson.encode, input)
+        self.assertRaises(OverflowError, ujson.encode, input)
 
     def test_encodeDoubleInf(self):
         input = float('inf')


### PR DESCRIPTION
Should fix #221 (avoid raising OverflowError when encoding object of type `numpy.int64` on python 3+ while staying compatible with python 2.7)

**Python 2.7**

``` python
Python 2.7.11+ (default, Apr 17 2016, 14:00:29) 
[GCC 5.3.1 20160413] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np, ujson
>>> li = [[i/2.0 for i in range(5)], [i/3.0 for i in range(5)]]
>>> arr = np.array(li)
>>> res1 = ujson.dumps(li)
>>> res2 = ujson.dumps(arr)
>>> print(res1)
[[0.0,0.5,1.0,1.5,2.0],[0.0,0.3333333333,0.6666666667,1.0,1.3333333333]]
>>> print(res2)
[[0.0,0.5,1.0,1.5,2.0],[0.0,0.3333333333,0.6666666667,1.0,1.3333333333]]
>>> li2 = [[i*i for i in range(5)],[i+i for i in range(5)]]
>>> arr2 = np.array(li2)
>>> res1 = ujson.dumps(li2)
>>> res2 = ujson.dumps(arr2)
>>> print(res1)
[[0,1,4,9,16],[0,2,4,6,8]]
>>> print(res2)
[[0,1,4,9,16],[0,2,4,6,8]]
```

**Python 3.5**

``` python
Python 3.5.1+ (default, Mar 30 2016, 22:46:26) 
[GCC 5.3.1 20160330] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np, ujson
>>> li = [[i/2.0 for i in range(5)], [i/3.0 for i in range(5)]]
>>> arr = np.array(li)
>>> res1 = ujson.dumps(li)
>>> res2 = ujson.dumps(arr)
>>> print(res1)
[[0.0,0.5,1.0,1.5,2.0],[0.0,0.3333333333,0.6666666667,1.0,1.3333333333]]
>>> print(res2)
[[0.0,0.5,1.0,1.5,2.0],[0.0,0.3333333333,0.6666666667,1.0,1.3333333333]]
>>> li2 = [[i*i for i in range(5)],[i+i for i in range(5)]]
>>> arr2 = np.array(li2)
>>> res1 = ujson.dumps(li2)
>>> res2 = ujson.dumps(arr2)
>>> print(res1)
[[0,1,4,9,16],[0,2,4,6,8]]
>>> print(res2)
[[0,1,4,9,16],[0,2,4,6,8]]

```
