### PR TITLE
Memory leak of dict values 

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -858,6 +858,7 @@ PyObject* objToJSONFile(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *string;
   PyObject *write;
   PyObject *argtuple;
+  PyObject *write_result;
 
   PRINTMARK();
 
@@ -900,13 +901,16 @@ PyObject* objToJSONFile(PyObject* self, PyObject *args, PyObject *kwargs)
     Py_XDECREF(write);
     return NULL;
   }
-  if (PyObject_CallObject (write, argtuple) == NULL)
+
+  write_result = PyObject_CallObject (write, argtuple);
+  if (write_result == NULL)
   {
     Py_XDECREF(write);
     Py_XDECREF(argtuple);
     return NULL;
   }
 
+  Py_DECREF(write_result);
   Py_XDECREF(write);
   Py_DECREF(argtuple);
   Py_XDECREF(string);

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -49,6 +49,8 @@ typedef void *(*PFN_PyTypeToJSON)(JSOBJ obj, JSONTypeContext *ti, void *outValue
 typedef ssize_t Py_ssize_t;
 #endif
 
+#define printf(s) fprintf(stderr, s)
+
 typedef struct __TypeContext
 {
   JSPFN_ITEREND iterEnd;
@@ -271,18 +273,24 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
 
   if (PyUnicode_Check(GET_TC(tc)->itemName))
   {
+    itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
+    Py_DECREF(itemNameTmp);
   }
   else
   if (!PyString_Check(GET_TC(tc)->itemName))
   {
     if (UNLIKELY(GET_TC(tc)->itemName == Py_None))
     {
+      itemNameTmp = GET_TC(tc)->itemName;
       GET_TC(tc)->itemName = PyString_FromString("null");
+      Py_DECREF(itemNameTmp);
       return 1;
     }
 
+    itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
+    Py_DECREF(itemNameTmp);
 #if PY_MAJOR_VERSION >= 3
     itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
@@ -291,7 +299,7 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
   }
   else
   {
-    Py_INCREF(GET_TC(tc)->itemName);
+//    Py_INCREF(GET_TC(tc)->itemName);
   }
   PRINTMARK();
   return 1;

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -259,8 +259,12 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
     return 0;
   }
 
-  if (!(GET_TC(tc)->itemValue = PyObject_GetItem(GET_TC(tc)->dictObj, GET_TC(tc)->itemName)))
-  {
+  if (GET_TC(tc)->itemValue) {
+    Py_DECREF(GET_TC(tc)->itemValue);
+    GET_TC(tc)->itemValue = NULL;
+  }
+
+  if (!(GET_TC(tc)->itemValue = PyObject_GetItem(GET_TC(tc)->dictObj, GET_TC(tc)->itemName))) {
     PRINTMARK();
     return 0;
   }
@@ -295,10 +299,13 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
 
 static void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc)
 {
-  if (GET_TC(tc)->itemName)
-  {
-    Py_DECREF(GET_TC(tc)->itemName);
-    GET_TC(tc)->itemName = NULL;
+  if (GET_TC(tc)->itemName) {
+      Py_DECREF(GET_TC(tc)->itemName);
+      GET_TC(tc)->itemName = NULL;
+  }
+  if (GET_TC(tc)->itemValue) {
+    Py_DECREF(GET_TC(tc)->itemValue);
+    GET_TC(tc)->itemValue = NULL;
   }
   Py_CLEAR(GET_TC(tc)->iterator);
   Py_DECREF(GET_TC(tc)->dictObj);

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -681,6 +681,10 @@ static void Object_endTypeContext(JSOBJ obj, JSONTypeContext *tc)
 {
   Py_XDECREF(GET_TC(tc)->newObj);
 
+  if (tc->type == JT_RAW)
+  {
+    Py_XDECREF(GET_TC(tc)->rawJSONValue);
+  }
   PyObject_Free(tc->prv);
   tc->prv = NULL;
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,6 @@ import json
 import math
 import time
 import sys
-import pytz
 
 if six.PY2:
     import unittest2 as unittest
@@ -817,6 +816,19 @@ class UltraJSONTests(unittest.TestCase):
         data = {"a": 1, "c": 1, "b": 1, "e": 1, "f": 1, "d": 1}
         sortedKeys = ujson.dumps(data, sort_keys=True)
         self.assertEqual(sortedKeys, '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1}')
+
+    def test_ujson_has_no_memory_leak(self):
+        import gc
+        import objgraph
+        gc.collect()
+        pre = dict(objgraph.most_common_types())
+        for value in range(10):
+            data = {"1": [value]}
+            s = ujson.dumps(data)
+            data = None
+        gc.collect()
+        post = dict(objgraph.most_common_types())
+        self.assertEqual(pre["list"], post["list"])
 
 """
 def test_decodeNumericIntFrcOverflow(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -817,19 +817,70 @@ class UltraJSONTests(unittest.TestCase):
         sortedKeys = ujson.dumps(data, sort_keys=True)
         self.assertEqual(sortedKeys, '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1}')
 
-    def test_ujson_has_no_memory_leak(self):
+    def test_does_not_leak_dictionary_values(self):
         import gc
-        import objgraph
         gc.collect()
-        pre = dict(objgraph.most_common_types())
-        for value in range(10):
-            data = {"1": [value]}
-            s = ujson.dumps(data)
-            data = None
-        gc.collect()
-        post = dict(objgraph.most_common_types())
-        self.assertEqual(pre["list"], post["list"])
+        value = ["abc"]
+        data = {"1": value}
+        ref_count = sys.getrefcount(value)
+        ujson.dumps(data)
+        self.assertEqual(ref_count, sys.getrefcount(value))
 
+    def test_does_not_leak_dictionary_keys(self):
+        import gc
+        gc.collect()
+        key1 = "1"
+        key2 = "1"
+        value1 = ["abc"]
+        value2 = [1,2,3]
+        data = {key1: value1, key2: value2}
+        ref_count1 = sys.getrefcount(key1)
+        ref_count2 = sys.getrefcount(key2)
+        ujson.dumps(data)
+        self.assertEqual(ref_count1, sys.getrefcount(key1))
+        self.assertEqual(ref_count2, sys.getrefcount(key2))
+
+    def test_does_not_leak_dictionary_string_key(self):
+        import gc
+        gc.collect()
+        key1 = "1"
+        value1 = 1
+        data = {key1: value1}
+        ref_count1 = sys.getrefcount(key1)
+        ujson.dumps(data)
+        self.assertEqual(ref_count1, sys.getrefcount(key1))
+
+    def test_does_not_leak_dictionary_tuple_key(self):
+        import gc
+        gc.collect()
+        key1 = ("a",)
+        value1 = 1
+        data = {key1: value1}
+        ref_count1 = sys.getrefcount(key1)
+        ujson.dumps(data)
+        self.assertEqual(ref_count1, sys.getrefcount(key1))
+
+    def test_does_not_leak_dictionary_bytes_key(self):
+        import gc
+        gc.collect()
+        key1 = b"1"
+        value1 = 1
+        data = {key1: value1}
+        ref_count1 = sys.getrefcount(key1)
+        ujson.dumps(data)
+        self.assertEqual(ref_count1, sys.getrefcount(key1))
+
+    def test_does_not_leak_dictionary_None_key(self):
+        import gc
+        gc.collect()
+        key1 = None
+        value1 = 1
+        data = {key1: value1}
+        ref_count1 = sys.getrefcount(key1)
+        ujson.dumps(data)
+        self.assertEqual(ref_count1, sys.getrefcount(key1))
+
+    
 """
 def test_decodeNumericIntFrcOverflow(self):
 input = "X.Y"


### PR DESCRIPTION
This change solves a memory leak, that happens when dumps a dictionary. All the values in the dictionary have their ref count increased. 
Note that there is still another memory leak in ujson that I haven't had a chance to find yet, but it is somewhat slower at least in our use.  