### PR TITLE
Reduce default buffer on stack size

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -77,7 +77,7 @@ tree doesn't have cyclic references.
 /*
 Dictates and limits how much stack space for buffers UltraJSON will use before resorting to provided heap functions */
 #ifndef JSON_MAX_STACK_BUFFER_SIZE
-#define JSON_MAX_STACK_BUFFER_SIZE 131072
+#define JSON_MAX_STACK_BUFFER_SIZE 1024
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Fix segfaults on musl libc when ultrajson runs in a thread. On musl libc
the default thread stack size is only 80k so allocating a 128k buffer on
stack will guarantee a crash. There seems not to be any evident
performance benefit using big buffer on stack either so we just reduce
the default.

fixes #254