### PR TITLE
Add Python 3.6, 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install six blist unittest2 pytz
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling dist: xenial for other build jobs
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
+  - "3.7"
+  - "3.8"
 install:
   - pip install six blist unittest2 pytz
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+# Enable 3.7 without globally enabling dist: xenial for other build jobs
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
 install:
   - pip install six blist unittest2 pytz
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.6"

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,15 @@
 UltraJSON
 =============
+.. image:: https://img.shields.io/pypi/v/ujson.svg?style=flat
+    :alt: PyPI version
+    :target: https://pypi.python.org/pypi/ujson
+
+.. image:: https://img.shields.io/pypi/pyversions/ujson.svg
+    :alt: Supported Python versions
+    :target: https://pypi.python.org/pypi/ujson
+
 .. image:: https://travis-ci.org/esnme/ultrajson.svg?branch=master
+    :alt: Travis CI build status
     :target: https://travis-ci.org/esnme/ultrajson
 
 UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.5+ and 3.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 """.splitlines()))
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,16 @@ Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved :: BSD License
 Programming Language :: C
+Programming Language :: Python :: 2
+Programming Language :: Python :: 2.5
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 """.splitlines()))
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")
@@ -99,5 +104,6 @@ setup(
     platforms=['any'],
     url="http://www.esn.me",
     cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
+    python_requires='>=2.5, !=3.0.*, !=3.1.*',
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 """.splitlines()))
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")


### PR DESCRIPTION
Also update the classifiers and add `python_requires` to help pip, and add PyPI badges.

The README says "Python 2.5+ and 3", so I've added in 2.5, 3.3 and 3.5 to the classifiers.

(See also https://github.com/esnme/ultrajson/issues/295 for discussion on dropping EOL versions 2.5, 2.6, 3.2 and 3.3.)