### PR TITLE
Drop EOL Python 2.5-2.6, 3.2-3.4 and add 3.7-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install six blist
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install six blist unittest2 pytz
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 install:
-  - pip install six blist unittest2 pytz
+  - pip install six blist
   - python setup.py install
 script: python tests/tests.py

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,15 @@
 UltraJSON
 =============
+.. image:: https://img.shields.io/pypi/v/ujson.svg?style=flat
+    :alt: PyPI version
+    :target: https://pypi.python.org/pypi/ujson
+
+.. image:: https://img.shields.io/pypi/pyversions/ujson.svg
+    :alt: Supported Python versions
+    :target: https://pypi.python.org/pypi/ujson
+
 .. image:: https://travis-ci.org/esnme/ultrajson.svg?branch=master
+    :alt: Travis CI build status
     :target: https://travis-ci.org/esnme/ultrajson
 
 UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.5+ and 3.

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ UltraJSON
     :alt: Travis CI build status
     :target: https://travis-ci.org/esnme/ultrajson
 
-UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.7 and 3.4+.
+UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.7 and 3.5+.
 
 For a more painless day to day C/C++ JSON decoder experience please checkout ujson4c_, based on UltraJSON.
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ UltraJSON
     :alt: Travis CI build status
     :target: https://travis-ci.org/esnme/ultrajson
 
-UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.5+ and 3.
+UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for Python 2.7 and 3.4+.
 
 For a more painless day to day C/C++ JSON decoder experience please checkout ujson4c_, based on UltraJSON.
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -45,10 +45,6 @@ static PyObject* type_decimal = NULL;
 
 typedef void *(*PFN_PyTypeToJSON)(JSOBJ obj, JSONTypeContext *ti, void *outValue, size_t *_outLen);
 
-#if (PY_VERSION_HEX < 0x02050000)
-typedef ssize_t Py_ssize_t;
-#endif
-
 typedef struct __TypeContext
 {
   JSPFN_ITEREND iterEnd;

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,16 @@ Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved :: BSD License
 Programming Language :: C
+Programming Language :: Python :: 2
+Programming Language :: Python :: 2.5
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.2
+Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 """.splitlines()))
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")
@@ -99,5 +104,6 @@ setup(
     platforms=['any'],
     url="http://www.esn.me",
     cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
+    python_requires='>=2.5, !=3.0.*, !=3.1.*',
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,11 @@ try:
   from setuptools import setup, Extension
 except ImportError:
   from distutils.core import setup, Extension
-import distutils.sysconfig
 from distutils.sysconfig import customize_compiler
 from distutils.command.build_clib import build_clib
 from distutils.command.build_ext import build_ext
 import os.path
 import re
-import sys
 from glob import glob
 
 CLASSIFIERS = filter(None, map(str.strip,
@@ -18,12 +16,8 @@ Intended Audience :: Developers
 License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.5
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
@@ -104,6 +98,6 @@ setup(
     platforms=['any'],
     url="http://www.esn.me",
     cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
-    python_requires='>=2.5, !=3.0.*, !=3.1.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ Programming Language :: C
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 """.splitlines()))
@@ -98,6 +97,6 @@ setup(
     platforms=['any'],
     url="http://www.esn.me",
     cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=CLASSIFIERS,
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 """.splitlines()))
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,7 +80,7 @@ class UltraJSONTests(unittest.TestCase):
         sut = {'a': 4.56}
         encoded = ujson.encode(sut)
         decoded = ujson.decode(encoded)
-        self.assertAlmostEqual(sut[u'a'], decoded[u'a'])
+        self.assertAlmostEqual(sut['a'], decoded['a'])
 
     def test_encodeDictWithUnicodeKeys(self):
         input = {"key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1"}
@@ -628,36 +628,36 @@ class UltraJSONTests(unittest.TestCase):
             def __json__(self):
                 return '"' + output_text + '"'
 
-        d = {u'key': JSONTest()}
+        d = {'key': JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {u'key': output_text})
+        self.assertEqual(dec, {'key': output_text})
 
     def test_object_with_json_unicode(self):
         # If __json__ returns a string, then that string
         # will be used as a raw JSON snippet in the object.
-        output_text = u'this is the correct output'
+        output_text = 'this is the correct output'
         class JSONTest:
             def __json__(self):
-                return u'"' + output_text + u'"'
+                return '"' + output_text + '"'
 
-        d = {u'key': JSONTest()}
+        d = {'key': JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {u'key': output_text})
+        self.assertEqual(dec, {'key': output_text})
 
     def test_object_with_complex_json(self):
         # If __json__ returns a string, then that string
         # will be used as a raw JSON snippet in the object.
-        obj = {u'foo': [u'bar', u'baz']}
+        obj = {'foo': ['bar', 'baz']}
         class JSONTest:
             def __json__(self):
                 return ujson.encode(obj)
 
-        d = {u'key': JSONTest()}
+        d = {'key': JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {u'key': obj})
+        self.assertEqual(dec, {'key': obj})
 
     def test_object_with_json_type_error(self):
         # __json__ must return a string, otherwise it should raise an error.
@@ -666,7 +666,7 @@ class UltraJSONTests(unittest.TestCase):
                 def __json__(self):
                     return return_value
 
-            d = {u'key': JSONTest()}
+            d = {'key': JSONTest()}
             self.assertRaises(TypeError, ujson.encode, d)
 
     def test_object_with_json_attribute_error(self):
@@ -675,7 +675,7 @@ class UltraJSONTests(unittest.TestCase):
             def __json__(self):
                 raise AttributeError
 
-        d = {u'key': JSONTest()}
+        d = {'key': JSONTest()}
         self.assertRaises(AttributeError, ujson.encode, d)
 
     def test_decodeArrayTrailingCommaFail(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,23 +1,16 @@
 ﻿# coding=UTF-8
 from __future__ import print_function, unicode_literals
-import six
-from six.moves import range, zip
 
-import calendar
-import functools
 import decimal
+import functools
 import json
 import math
-import time
-import sys
-import pytz
+import unittest
 
-if six.PY2:
-    import unittest2 as unittest
-else:
-    import unittest
+import six
 
 import ujson
+from six.moves import range, zip
 
 json_unicode = json.dumps if six.PY3 else functools.partial(json.dumps, encoding="utf-8")
 
@@ -348,7 +341,6 @@ class UltraJSONTests(unittest.TestCase):
         input = -float('inf')
         self.assertRaises(OverflowError, ujson.encode, input)
 
-    @unittest.skipIf(sys.version_info < (2, 7), "No Ordered dict in < 2.7")
     def test_encodeOrderedDict(self):
         from collections import OrderedDict
         input = OrderedDict([(1, 1), (0, 0), (8, 8), (2, 2)])


### PR DESCRIPTION
Fixes https://github.com/esnme/ultrajson/issues/295.

Also removes some unused imports.