### PR TITLE
Test on Python 3.9-dev to avoid surprises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: false
 language: python
+
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.9-dev"
+
 install:
   - pip install six blist unittest2 pytz
   - python setup.py install


### PR DESCRIPTION
Python 3.9 is in alpha and will be officially released in October.

Remove EOL and failing 2.6 and 3.3, they've been removed from Travis.