### PR TITLE
Test on new Travis CPUs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
 language: python
 
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
+
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 
 arch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 arch:
   - amd64


### PR DESCRIPTION
Travis CI has recently made available new CPU architectures, in addition to the existing `amd64`.

* In July, they added `arm64` (Arm support)
  https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support

* In November, they added `ppc64le` (IBM Power) and `s390x` (IBM Z CPU)
https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z

* `s390x` is particularly useful as it's big-endian
