### PR TITLE
Fix Warning: 'classifiers' should be a list, got type 'filter'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ import re
 import sys
 from glob import glob
 
-CLASSIFIERS = filter(None, map(str.strip,
-"""
+CLASSIFIERS = """
 Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved :: BSD License
@@ -22,7 +21,7 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.4
-""".splitlines()))
+"""
 
 source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 source_files.append("./lib/dconv_wrapper.cc")
@@ -98,5 +97,5 @@ setup(
     platforms=['any'],
     url="http://www.esn.me",
     cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
-    classifiers=CLASSIFIERS,
+    classifiers=[x for x in CLASSIFIERS.split("\n") if x],
 )


### PR DESCRIPTION
# Before

```console
$ python setup.py --classifiers
Warning: 'classifiers' should be a list, got type 'filter'
Development Status :: 5 - Production/Stable
Intended Audience :: Developers
License :: OSI Approved :: BSD License
Programming Language :: C
Programming Language :: Python :: 2.6
Programming Language :: Python :: 2.7
Programming Language :: Python :: 3
Programming Language :: Python :: 3.2
Programming Language :: Python :: 3.4
```

# After

```console
$ python setup.py --classifiers
Development Status :: 5 - Production/Stable
Intended Audience :: Developers
License :: OSI Approved :: BSD License
Programming Language :: C
Programming Language :: Python :: 2.6
Programming Language :: Python :: 2.7
Programming Language :: Python :: 3
Programming Language :: Python :: 3.2
Programming Language :: Python :: 3.4
```

This is how CPython does it:

* https://github.com/python/cpython/blob/c2ac4cf040ea950bf552d1e77bea613a1a5474fe/setup.py#L69-L76
* https://github.com/python/cpython/blob/c2ac4cf040ea950bf552d1e77bea613a1a5474fe/setup.py#L2414
