### PR TITLE
Fix reference counting bug for dict values

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -255,7 +255,7 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
     return 0;
   }
 
-  if (!(GET_TC(tc)->itemValue = PyObject_GetItem(GET_TC(tc)->dictObj, GET_TC(tc)->itemName)))
+  if (!(GET_TC(tc)->itemValue = PyDict_GetItem(GET_TC(tc)->dictObj, GET_TC(tc)->itemName)))
   {
     PRINTMARK();
     return 0;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -5,6 +5,7 @@ import decimal
 import functools
 import json
 import math
+import sys
 import unittest
 
 import six
@@ -294,6 +295,16 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(input, json.loads(output))
         self.assertEqual(input, ujson.decode(output))
         self.assertEqual(input, ujson.decode(output))
+
+    def test_encodeDictValuesRefCounting(self):
+        import gc
+
+        gc.collect()
+        value = ["abc"]
+        data = {"1": value}
+        ref_count = sys.getrefcount(value)
+        ujson.dumps(data)
+        self.assertEqual(ref_count, sys.getrefcount(value))
 
     def test_encodeNoneConversion(self):
         input = None


### PR DESCRIPTION
which meant a memory leak.

PyObject_GetItem returns a new reference (and goes through
abstract object[key] API), whereas PyDict_GetItem returns a borrowed
reference and goes directly to the dict hash lookup.