### PR TITLE
Lint with pre-commit: Black, isort, Flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: lint-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            lint-pip-
+
+      - name: pre-commit cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            lint-pre-commit-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+
+      - name: Lint
+        run: pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install six blist
-          python setup.py install
+          python -m pip install --upgrade six blist
+          python -m pip install .
 
       - name: Tests
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,135 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.0.1
+    hooks:
+      - id: pyupgrade
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        args: ["--target-version", "py27"]
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
+
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.0.0
+    hooks:
+      - id: seed-isort-config
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.5.1
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: rst-backticks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ python:
   - "3.8"
   - "3.9-dev"
 
+matrix:
+  fast_finish: true
+
 install:
-  - pip install six blist
-  - python setup.py install
+  - pip install -U pip
+  - pip install -U six blist
+  - pip install .
 
 script: python tests/tests.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target_version = ["py27"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+max_line_length = 88
+
+[tool:isort]
+known_third_party = six,ujson
+force_grid_wrap = 0
+include_trailing_comma = True
+line_length = 88
+multi_line_output = 3
+use_parentheses = True

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 try:
-  from setuptools import setup, Extension
+    from setuptools import setup, Extension
 except ImportError:
-  from distutils.core import setup, Extension
-from distutils.sysconfig import customize_compiler
-from distutils.command.build_clib import build_clib
-from distutils.command.build_ext import build_ext
+    from distutils.core import setup, Extension
 import os.path
 import re
+from distutils.command.build_clib import build_clib
+from distutils.command.build_ext import build_ext
+from distutils.sysconfig import customize_compiler
 from glob import glob
 
 CLASSIFIERS = """
@@ -27,12 +27,12 @@ source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 source_files.append("./lib/dconv_wrapper.cc")
 
 libdoubleconversion = (
-    'double-conversion',
+    "double-conversion",
     dict(
-        sources = source_files,
-        include_dirs = ["./deps/double-conversion/double-conversion"],
-        language = "c++"
-    )
+        sources=source_files,
+        include_dirs=["./deps/double-conversion/double-conversion"],
+        language="c++",
+    ),
 )
 
 
@@ -49,22 +49,22 @@ class build_clib_without_warnings(build_clib):
 
 
 module1 = Extension(
-    'ujson',
-     sources = [
-         './python/ujson.c',
-         './python/objToJSON.c',
-         './python/JSONtoObj.c',
-         './lib/ultrajsonenc.c',
-         './lib/ultrajsondec.c'
-     ],
-     include_dirs = ['./python', './lib'],
-     extra_compile_args = ['-D_GNU_SOURCE'],
-     extra_link_args = ['-lstdc++', '-lm']
+    "ujson",
+    sources=[
+        "./python/ujson.c",
+        "./python/objToJSON.c",
+        "./python/JSONtoObj.c",
+        "./lib/ultrajsonenc.c",
+        "./lib/ultrajsondec.c",
+    ],
+    include_dirs=["./python", "./lib"],
+    extra_compile_args=["-D_GNU_SOURCE"],
+    extra_link_args=["-lstdc++", "-lm"],
 )
 
 
 def get_version():
-    filename = os.path.join(os.path.dirname(__file__), './python/version.h')
+    filename = os.path.join(os.path.dirname(__file__), "./python/version.h")
     file = None
     try:
         file = open(filename)
@@ -77,26 +77,26 @@ def get_version():
     return m.group(1)
 
 
-f = open('README.rst')
+f = open("README.rst")
 try:
     README = f.read()
 finally:
-    f.close()    
-    
+    f.close()
+
 
 setup(
-    name = 'ujson',
-    version = get_version(),
-    description = "Ultra fast JSON encoder and decoder for Python",
-    long_description = README,
-    libraries = [libdoubleconversion],
-    ext_modules = [module1],
+    name="ujson",
+    version=get_version(),
+    description="Ultra fast JSON encoder and decoder for Python",
+    long_description=README,
+    libraries=[libdoubleconversion],
+    ext_modules=[module1],
     author="Jonas Tarnstrom",
     author_email="jonas.tarnstrom@esn.me",
     download_url="https://github.com/esnme/ultrajson",
-    platforms=['any'],
+    platforms=["any"],
     url="http://www.esn.me",
-    cmdclass = {'build_ext': build_ext, 'build_clib': build_clib_without_warnings},
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    cmdclass={"build_ext": build_ext, "build_clib": build_clib_without_warnings},
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[x for x in CLASSIFIERS.split("\n") if x],
 )

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,5 +1,6 @@
 ﻿# coding=UTF-8
 from __future__ import division, print_function, unicode_literals
+
 import json
 import os
 import platform
@@ -9,7 +10,17 @@ import timeit
 
 import ujson
 
-USER = {"userId": 3381293, "age": 213, "username": "johndoe", "fullname": "John Doe the Second", "isAuthorized": True, "liked": 31231.31231202, "approval": 31.1471, "jobs": [1, 2], "currJob": None}
+USER = {
+    "userId": 3381293,
+    "age": 213,
+    "username": "johndoe",
+    "fullname": "John Doe the Second",
+    "isAuthorized": True,
+    "liked": 31231.31231202,
+    "approval": 31.1471,
+    "jobs": [1, 2],
+    "currJob": None,
+}
 FRIENDS = [USER, USER, USER, USER, USER, USER, USER, USER]
 
 decode_data = None
@@ -34,13 +45,22 @@ def results_record_result(callback, is_encode, count):
     callback_name = callback.__name__
     library = callback_name.split("_")[-1]
     try:
-      results = timeit.repeat("{}()".format(callback_name), "from __main__ import {}".format(callback_name), repeat=10, number=count)
+        results = timeit.repeat(
+            "{}()".format(callback_name),
+            "from __main__ import {}".format(callback_name),
+            repeat=10,
+            number=count,
+        )
     except TypeError:
-      return
+        return
     result = count / min(results)
     benchmark_results[-1][1 if is_encode else 2][library] = result
 
-    print("{} {}: {:.02f} calls/sec".format(library, "encode" if is_encode else "decode", result))
+    print(
+        "{} {}: {:.02f} calls/sec".format(
+            library, "encode" if is_encode else "decode", result
+        )
+    )
 
 
 def results_output_table():
@@ -58,7 +78,11 @@ def results_output_table():
     print("Versions:")
     print("~~~~~~~~~")
     print()
-    print("- {} {}".format(platform.python_implementation(), sys.version.replace("\n", "")))
+    print(
+        "- {} {}".format(
+            platform.python_implementation(), sys.version.replace("\n", "")
+        )
+    )
     print("- blist     : 1.3.6")
     print("- simplejson: 3.8.1")
     print("- ujson     : 1.34")
@@ -69,8 +93,8 @@ def results_output_table():
     for library in LIBRARIES:
         column_widths.append(max(10, len(library)))
 
-    line = "+{}+".format("+".join("-"*(width + 2) for width in column_widths))
-    columns = [" "*(width + 2) for width in column_widths]
+    line = "+{}+".format("+".join("-" * (width + 2) for width in column_widths))
+    columns = [" " * (width + 2) for width in column_widths]
     for i, library in enumerate(LIBRARIES):
         columns[i + 1] = (" " + library).ljust(column_widths[i + 1] + 2)
     print(line)
@@ -78,7 +102,7 @@ def results_output_table():
     print(line.replace("-", "="))
 
     for name, encodes, decodes in benchmark_results:
-        columns = [" "*(width + 2) for width in column_widths]
+        columns = [" " * (width + 2) for width in column_widths]
         columns[0] = (" " + name).ljust(column_widths[0] + 2)
         print("|{}|".format("|".join(columns)))
         print(line)
@@ -87,9 +111,11 @@ def results_output_table():
         columns[0] = " encode".ljust(column_widths[0] + 2)
         for i, library in enumerate(LIBRARIES):
             if library in encodes:
-                columns[i + 1] = "{:.2f} ".format(encodes[library]).rjust(column_widths[i + 1] + 2)
+                columns[i + 1] = "{:.2f} ".format(encodes[library]).rjust(
+                    column_widths[i + 1] + 2
+                )
             else:
-                columns[i + 1] = " "*(column_widths[i + 1] + 2)
+                columns[i + 1] = " " * (column_widths[i + 1] + 2)
         print("|{}|".format("|".join(columns)))
         print(line)
 
@@ -98,9 +124,11 @@ def results_output_table():
             columns[0] = " decode".ljust(column_widths[0] + 2)
             for i, library in enumerate(LIBRARIES):
                 if library in decodes:
-                    columns[i + 1] = "{:.2f} ".format(decodes[library]).rjust(column_widths[i + 1] + 2)
+                    columns[i + 1] = "{:.2f} ".format(decodes[library]).rjust(
+                        column_widths[i + 1] + 2
+                    )
                 else:
-                    columns[i + 1] = " "*(column_widths[i + 1] + 2)
+                    columns[i + 1] = " " * (column_widths[i + 1] + 2)
             print("|{}|".format("|".join(columns)))
             print(line)
 
@@ -208,7 +236,11 @@ def benchmark_array_utf8_strings():
 
     test_object = []
     for x in range(256):
-        test_object.append("نظام الحكم سلطاني وراثي في الذكور من ذرية السيد تركي بن سعيد بن سلطان ويشترط فيمن يختار لولاية الحكم من بينهم ان يكون مسلما رشيدا عاقلا ًوابنا شرعيا لابوين عمانيين ")
+        test_object.append(
+            "نظام الحكم سلطاني وراثي "
+            "في الذكور من ذرية السيد تركي بن سعيد بن سلطان ويشترط فيمن يختار لولاية"
+            " الحكم من بينهم ان يكون مسلما رشيدا عاقلا ًوابنا شرعيا لابوين عمانيين "
+        )
     run_encode(COUNT)
 
     decode_data = json.dumps(test_object)
@@ -240,7 +272,14 @@ def benchmark_medium_complex_object():
     results_new_benchmark("Medium complex object")
     COUNT = 5000
 
-    test_object = [[USER, FRIENDS], [USER, FRIENDS], [USER, FRIENDS], [USER, FRIENDS], [USER, FRIENDS], [USER, FRIENDS]]
+    test_object = [
+        [USER, FRIENDS],
+        [USER, FRIENDS],
+        [USER, FRIENDS],
+        [USER, FRIENDS],
+        [USER, FRIENDS],
+        [USER, FRIENDS],
+    ]
     run_encode(COUNT)
 
     decode_data = json.dumps(test_object)
@@ -274,7 +313,7 @@ def benchmark_array_of_dict_string_int_pairs():
 
     test_object = []
     for x in range(256):
-        test_object.append({str(random.random()*20): int(random.random()*1000000)})
+        test_object.append({str(random.random() * 20): int(random.random() * 1000000)})
     run_encode(COUNT)
 
     decode_data = json.dumps(test_object)
@@ -293,8 +332,8 @@ def benchmark_dict_of_arrays_of_dict_string_int_pairs():
     for y in range(256):
         arrays = []
         for x in range(256):
-            arrays.append({str(random.random()*20): int(random.random()*1000000)})
-        test_object[str(random.random()*20)] = arrays
+            arrays.append({str(random.random() * 20): int(random.random() * 1000000)})
+        test_object[str(random.random() * 20)] = arrays
     run_encode(COUNT)
 
     decode_data = json.dumps(test_object)
@@ -302,7 +341,9 @@ def benchmark_dict_of_arrays_of_dict_string_int_pairs():
 
     decode_data = None
 
-    results_new_benchmark("Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys")
+    results_new_benchmark(
+        "Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys"
+    )
     run_encode_sort_keys(COUNT)
 
     test_object = None
@@ -314,7 +355,7 @@ def benchmark_complex_object():
     COUNT = 100
 
     with open(os.path.join(os.path.dirname(__file__), "sample.json"), "r") as f:
-       test_object = json.load(f)
+        test_object = json.load(f)
     run_encode(COUNT)
 
     decode_data = json.dumps(test_object)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@ import ujson
 from six.moves import range, zip
 
 json_unicode = (
-    json.dumps if six.PY3 else functools.partial(json.dumps, encoding="utf-8")
+    functools.partial(json.dumps, encoding="utf-8") if six.PY2 else json.dumps
 )
 
 
@@ -215,10 +215,10 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(s, decoded)
 
         # ujson outputs an UTF-8 encoded str object
-        if six.PY3:
-            encoded = ujson.dumps(s, ensure_ascii=False)
-        else:
+        if six.PY2:
             encoded = ujson.dumps(s, ensure_ascii=False).decode("utf-8")
+        else:
+            encoded = ujson.dumps(s, ensure_ascii=False)
 
         # json outputs an unicode object
         encoded_json = json.dumps(s, ensure_ascii=False)
@@ -237,10 +237,10 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(s, decoded)
 
         # ujson outputs an UTF-8 encoded str object
-        if six.PY3:
-            encoded = ujson.dumps(s, ensure_ascii=False)
-        else:
+        if six.PY2:
             encoded = ujson.dumps(s, ensure_ascii=False).decode("utf-8")
+        else:
+            encoded = ujson.dumps(s, ensure_ascii=False)
 
         # json outputs an unicode object
         encoded_json = json.dumps(s, ensure_ascii=False)
@@ -318,7 +318,7 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_encodeToUTF8(self):
         input = b"\xe6\x97\xa5\xd1\x88"
-        if six.PY3:
+        if not six.PY2:
             input = input.decode("utf-8")
         enc = ujson.encode(input, ensure_ascii=False)
         dec = ujson.decode(enc)
@@ -624,21 +624,21 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_encodeBigEscape(self):
         for x in range(10):
-            if six.PY3:
-                base = "\u00e5".encode("utf-8")
-            else:
+            if six.PY2:
                 base = "\xc3\xa5"
+            else:
+                base = "\u00e5".encode("utf-8")
             input = base * 1024 * 1024 * 2
             ujson.encode(input)
 
     def test_decodeBigEscape(self):
         for x in range(10):
-            if six.PY3:
-                base = "\u00e5".encode("utf-8")
-                quote = b'"'
-            else:
+            if six.PY2:
                 base = "\xc3\xa5"
                 quote = '"'
+            else:
+                base = "\u00e5".encode("utf-8")
+                quote = b'"'
             input = quote + (base * 1024 * 1024 * 2) + quote
             ujson.decode(input)
 
@@ -841,7 +841,7 @@ class UltraJSONTests(unittest.TestCase):
     def test_WriteArrayOfSymbolsFromTuple(self):
         self.assertEqual("[true,false,null]", ujson.dumps((True, False, None)))
 
-    @unittest.skipIf(not six.PY3, "Only raises on Python 3")
+    @unittest.skipIf(six.PY2, "Only raises on Python 3")
     def test_encodingInvalidUnicodeCharacter(self):
         s = "\udc7f"
         self.assertRaises(UnicodeEncodeError, ujson.dumps, s)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,11 +8,12 @@ import math
 import unittest
 
 import six
-
 import ujson
 from six.moves import range, zip
 
-json_unicode = json.dumps if six.PY3 else functools.partial(json.dumps, encoding="utf-8")
+json_unicode = (
+    json.dumps if six.PY3 else functools.partial(json.dumps, encoding="utf-8")
+)
 
 
 class UltraJSONTests(unittest.TestCase):
@@ -25,13 +26,15 @@ class UltraJSONTests(unittest.TestCase):
     def test_encodeStringConversion(self):
         input = "A string \\ / \b \f \n \r \t </script> &"
         not_html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t <\\/script> &"'
-        html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t \\u003c\\/script\\u003e \\u0026"'
+        html_encoded = (
+            '"A string \\\\ \\/ \\b \\f \\n \\r \\t \\u003c\\/script\\u003e \\u0026"'
+        )
         not_slashes_escaped = '"A string \\\\ / \\b \\f \\n \\r \\t </script> &"'
 
         def helper(expected_output, **encode_kwargs):
             output = ujson.encode(input, **encode_kwargs)
             self.assertEqual(output, expected_output)
-            if encode_kwargs.get('escape_forward_slashes', True):
+            if encode_kwargs.get("escape_forward_slashes", True):
                 self.assertEqual(input, json.loads(output))
                 self.assertEqual(input, ujson.decode(output))
 
@@ -51,10 +54,13 @@ class UltraJSONTests(unittest.TestCase):
         helper(not_slashes_escaped, escape_forward_slashes=False)
 
     def testWriteEscapedString(self):
-        self.assertEqual('"\\u003cimg src=\'\\u0026amp;\'\\/\\u003e"', ujson.dumps("<img src='&amp;'/>", encode_html_chars=True))
+        self.assertEqual(
+            "\"\\u003cimg src='\\u0026amp;'\\/\\u003e\"",
+            ujson.dumps("<img src='&amp;'/>", encode_html_chars=True),
+        )
 
     def test_doubleLongIssue(self):
-        sut = {'a': -4342969734183514}
+        sut = {"a": -4342969734183514}
         encoded = json.dumps(sut)
         decoded = json.loads(encoded)
         self.assertEqual(sut, decoded)
@@ -63,7 +69,7 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(sut, decoded)
 
     def test_doubleLongDecimalIssue(self):
-        sut = {'a': -12345678901234.56789012}
+        sut = {"a": -12345678901234.56789012}
         encoded = json.dumps(sut)
         decoded = json.loads(encoded)
         self.assertEqual(sut, decoded)
@@ -72,21 +78,36 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(sut, decoded)
 
     def test_encodeDecodeLongDecimal(self):
-        sut = {'a': -528656961.4399388}
+        sut = {"a": -528656961.4399388}
         encoded = ujson.dumps(sut)
         ujson.decode(encoded)
 
     def test_decimalDecodeTest(self):
-        sut = {'a': 4.56}
+        sut = {"a": 4.56}
         encoded = ujson.encode(sut)
         decoded = ujson.decode(encoded)
-        self.assertAlmostEqual(sut['a'], decoded['a'])
+        self.assertAlmostEqual(sut["a"], decoded["a"])
 
     def test_encodeDictWithUnicodeKeys(self):
-        input = {"key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1", "key1": "value1"}
+        input = {
+            "key1": "value1",
+            "key1": "value1",
+            "key1": "value1",
+            "key1": "value1",
+            "key1": "value1",
+            "key1": "value1",
+        }
         ujson.encode(input)
 
-        input = {"بن": "value1", "بن": "value1", "بن": "value1", "بن": "value1", "بن": "value1", "بن": "value1", "بن": "value1"}
+        input = {
+            "بن": "value1",
+            "بن": "value1",
+            "بن": "value1",
+            "بن": "value1",
+            "بن": "value1",
+            "بن": "value1",
+            "بن": "value1",
+        }
         ujson.encode(input)
 
     def test_encodeDoubleConversion(self):
@@ -111,14 +132,14 @@ class UltraJSONTests(unittest.TestCase):
         input = [[[[]]]] * 20
         output = ujson.encode(input)
         self.assertEqual(input, json.loads(output))
-        #self.assertEqual(output, json.dumps(input))
+        # self.assertEqual(output, json.dumps(input))
         self.assertEqual(input, ujson.decode(output))
 
     def test_encodeArrayOfDoubles(self):
         input = [31337.31337, 31337.31337, 31337.31337, 31337.31337] * 10
         output = ujson.encode(input)
         self.assertEqual(input, json.loads(output))
-        #self.assertEqual(output, json.dumps(input))
+        # self.assertEqual(output, json.dumps(input))
         self.assertEqual(input, ujson.decode(output))
 
     def test_encodeStringConversion2(self):
@@ -180,7 +201,7 @@ class UltraJSONTests(unittest.TestCase):
     # 16 bits) are represented as \UXXXXXXXX in python but should be encoded
     # as \uXXXX\uXXXX in json.
     def testEncodeUnicodeBMP(self):
-        s = '\U0001f42e\U0001f42e\U0001F42D\U0001F42D'  # 🐮🐮🐭🐭
+        s = "\U0001f42e\U0001f42e\U0001F42D\U0001F42D"  # 🐮🐮🐭🐭
         encoded = ujson.dumps(s)
         encoded_json = json.dumps(s)
 
@@ -207,7 +228,7 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual(s, decoded)
 
     def testEncodeSymbols(self):
-        s = '\u273f\u2661\u273f'  # ✿♡✿
+        s = "\u273f\u2661\u273f"  # ✿♡✿
         encoded = ujson.dumps(s)
         encoded_json = json.dumps(s)
         self.assertEqual(len(encoded), len(s) * 6 + 2)  # 6 characters + quotes
@@ -298,14 +319,14 @@ class UltraJSONTests(unittest.TestCase):
     def test_encodeToUTF8(self):
         input = b"\xe6\x97\xa5\xd1\x88"
         if six.PY3:
-            input = input.decode('utf-8')
+            input = input.decode("utf-8")
         enc = ujson.encode(input, ensure_ascii=False)
         dec = ujson.decode(enc)
         self.assertEqual(enc, json.dumps(input, ensure_ascii=False))
         self.assertEqual(dec, json.loads(enc))
 
     def test_decodeFromUnicode(self):
-        input = "{\"obj\": 31337}"
+        input = '{"obj": 31337}'
         dec1 = ujson.decode(input)
         dec2 = ujson.decode(str(input))
         self.assertEqual(dec1, dec2)
@@ -330,19 +351,20 @@ class UltraJSONTests(unittest.TestCase):
         self.assertRaises(OverflowError, ujson.encode, input)
 
     def test_encodeDoubleNan(self):
-        input = float('nan')
+        input = float("nan")
         self.assertRaises(OverflowError, ujson.encode, input)
 
     def test_encodeDoubleInf(self):
-        input = float('inf')
+        input = float("inf")
         self.assertRaises(OverflowError, ujson.encode, input)
 
     def test_encodeDoubleNegInf(self):
-        input = -float('inf')
+        input = -float("inf")
         self.assertRaises(OverflowError, ujson.encode, input)
 
     def test_encodeOrderedDict(self):
         from collections import OrderedDict
+
         input = OrderedDict([(1, 1), (0, 0), (8, 8), (2, 2)])
         self.assertEqual('{"1":1,"0":0,"8":8,"2":2}', ujson.encode(input))
 
@@ -363,7 +385,7 @@ class UltraJSONTests(unittest.TestCase):
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeArrayDepthTooBig(self):
-        input = '[' * (1024 * 1024)
+        input = "[" * (1024 * 1024)
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeBrokenObjectEnd(self):
@@ -371,19 +393,19 @@ class UltraJSONTests(unittest.TestCase):
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeObjectDepthTooBig(self):
-        input = '{' * (1024 * 1024)
+        input = "{" * (1024 * 1024)
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeStringUnterminated(self):
-        input = "\"TESTING"
+        input = '"TESTING'
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeStringUntermEscapeSequence(self):
-        input = "\"TESTING\\\""
+        input = '"TESTING\\"'
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeStringBadEscape(self):
-        input = "\"TESTING\\\""
+        input = '"TESTING\\"'
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeTrueBroken(self):
@@ -409,7 +431,7 @@ class UltraJSONTests(unittest.TestCase):
             self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeBrokenListLeakTest(self):
-        input = '[[[true'
+        input = "[[[true"
         for x in range(1000):
             self.assertRaises(ValueError, ujson.decode, input)
 
@@ -418,11 +440,11 @@ class UltraJSONTests(unittest.TestCase):
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeDictWithNoColonOrValue(self):
-        input = "{{{{\"key\"}}}}"
+        input = '{{{{"key"}}}}'
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeDictWithNoValue(self):
-        input = "{{{{\"key\":}}}}"
+        input = '{{{{"key":}}}}'
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeNumericIntPos(self):
@@ -453,12 +475,18 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual('"  \\u0000\\r\\n "', ujson.dumps("  \u0000\r\n "))
 
     def test_decodeNullCharacter(self):
-        input = "\"31337 \\u0000 31337\""
+        input = '"31337 \\u0000 31337"'
         self.assertEqual(ujson.decode(input), json.loads(input))
 
     def test_encodeListLongConversion(self):
-        input = [9223372036854775807, 9223372036854775807, 9223372036854775807,
-                 9223372036854775807, 9223372036854775807, 9223372036854775807]
+        input = [
+            9223372036854775807,
+            9223372036854775807,
+            9223372036854775807,
+            9223372036854775807,
+            9223372036854775807,
+            9223372036854775807,
+        ]
         output = ujson.encode(input)
         self.assertEqual(input, json.loads(output))
         self.assertEqual(input, ujson.decode(output))
@@ -533,7 +561,7 @@ class UltraJSONTests(unittest.TestCase):
     def test_dumpToFileLikeObject(self):
         class filelike:
             def __init__(self):
-                self.bytes = ''
+                self.bytes = ""
 
             def write(self, bytes):
                 self.bytes += bytes
@@ -543,7 +571,7 @@ class UltraJSONTests(unittest.TestCase):
         self.assertEqual("[1,2,3]", f.bytes)
 
     def test_dumpFileArgsError(self):
-        self.assertRaises(TypeError, ujson.dump, [], '')
+        self.assertRaises(TypeError, ujson.dump, [], "")
 
     def test_loadFile(self):
         f = six.StringIO("[1,2,3,4]")
@@ -566,30 +594,38 @@ class UltraJSONTests(unittest.TestCase):
 
     def test_version(self):
         if six.PY2:
-            self.assertRegexpMatches(ujson.__version__, r'^\d+\.\d+(\.\d+)?$', "ujson.__version__ must be a string like '1.4.0'")
+            self.assertRegexpMatches(
+                ujson.__version__,
+                r"^\d+\.\d+(\.\d+)?$",
+                "ujson.__version__ must be a string like '1.4.0'",
+            )
         else:
-            self.assertRegex(ujson.__version__, r'^\d+\.\d+(\.\d+)?$', "ujson.__version__ must be a string like '1.4.0'")
+            self.assertRegex(
+                ujson.__version__,
+                r"^\d+\.\d+(\.\d+)?$",
+                "ujson.__version__ must be a string like '1.4.0'",
+            )
 
     def test_encodeNumericOverflow(self):
         self.assertRaises(OverflowError, ujson.encode, 12839128391289382193812939)
 
     def test_decodeNumberWith32bitSignBit(self):
-        #Test that numbers that fit within 32 bits but would have the
+        # Test that numbers that fit within 32 bits but would have the
         # sign bit set (2**31 <= x < 2**32) are decoded properly.
         docs = (
             '{"id": 3590016419}',
-            '{"id": %s}' % 2**31,
-            '{"id": %s}' % 2**32,
-            '{"id": %s}' % ((2**32)-1),
+            '{"id": %s}' % 2 ** 31,
+            '{"id": %s}' % 2 ** 32,
+            '{"id": %s}' % ((2 ** 32) - 1),
         )
-        results = (3590016419, 2**31, 2**32, 2**32-1)
+        results = (3590016419, 2 ** 31, 2 ** 32, 2 ** 32 - 1)
         for doc, result in zip(docs, results):
-            self.assertEqual(ujson.decode(doc)['id'], result)
+            self.assertEqual(ujson.decode(doc)["id"], result)
 
     def test_encodeBigEscape(self):
         for x in range(10):
             if six.PY3:
-                base = '\u00e5'.encode('utf-8')
+                base = "\u00e5".encode("utf-8")
             else:
                 base = "\xc3\xa5"
             input = base * 1024 * 1024 * 2
@@ -598,11 +634,11 @@ class UltraJSONTests(unittest.TestCase):
     def test_decodeBigEscape(self):
         for x in range(10):
             if six.PY3:
-                base = '\u00e5'.encode('utf-8')
-                quote = "\"".encode()
+                base = "\u00e5".encode("utf-8")
+                quote = b'"'
             else:
                 base = "\xc3\xa5"
-                quote = "\""
+                quote = '"'
             input = quote + (base * 1024 * 1024 * 2) + quote
             ujson.decode(input)
 
@@ -612,8 +648,9 @@ class UltraJSONTests(unittest.TestCase):
         class DictTest:
             def toDict(self):
                 return d
+
             def __json__(self):
-                return '"json defined"' # Fallback and shouldn't be called.
+                return '"json defined"'  # Fallback and shouldn't be called.
 
         o = DictTest()
         output = ujson.encode(o)
@@ -623,50 +660,54 @@ class UltraJSONTests(unittest.TestCase):
     def test_object_with_json(self):
         # If __json__ returns a string, then that string
         # will be used as a raw JSON snippet in the object.
-        output_text = 'this is the correct output'
+        output_text = "this is the correct output"
+
         class JSONTest:
             def __json__(self):
                 return '"' + output_text + '"'
 
-        d = {'key': JSONTest()}
+        d = {"key": JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {'key': output_text})
+        self.assertEqual(dec, {"key": output_text})
 
     def test_object_with_json_unicode(self):
         # If __json__ returns a string, then that string
         # will be used as a raw JSON snippet in the object.
-        output_text = 'this is the correct output'
+        output_text = "this is the correct output"
+
         class JSONTest:
             def __json__(self):
                 return '"' + output_text + '"'
 
-        d = {'key': JSONTest()}
+        d = {"key": JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {'key': output_text})
+        self.assertEqual(dec, {"key": output_text})
 
     def test_object_with_complex_json(self):
         # If __json__ returns a string, then that string
         # will be used as a raw JSON snippet in the object.
-        obj = {'foo': ['bar', 'baz']}
+        obj = {"foo": ["bar", "baz"]}
+
         class JSONTest:
             def __json__(self):
                 return ujson.encode(obj)
 
-        d = {'key': JSONTest()}
+        d = {"key": JSONTest()}
         output = ujson.encode(d)
         dec = ujson.decode(output)
-        self.assertEqual(dec, {'key': obj})
+        self.assertEqual(dec, {"key": obj})
 
     def test_object_with_json_type_error(self):
         # __json__ must return a string, otherwise it should raise an error.
         for return_value in (None, 1234, 12.34, True, {}):
+
             class JSONTest:
                 def __json__(self):
                     return return_value
 
-            d = {'key': JSONTest()}
+            d = {"key": JSONTest()}
             self.assertRaises(TypeError, ujson.encode, d)
 
     def test_object_with_json_attribute_error(self):
@@ -675,7 +716,7 @@ class UltraJSONTests(unittest.TestCase):
             def __json__(self):
                 raise AttributeError
 
-        d = {'key': JSONTest()}
+        d = {"key": JSONTest()}
         self.assertRaises(AttributeError, ujson.encode, d)
 
     def test_decodeArrayTrailingCommaFail(self):
@@ -745,7 +786,7 @@ class UltraJSONTests(unittest.TestCase):
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeArrayWithBigInt(self):
-        input = '[18446744073709551616]'
+        input = "[18446744073709551616]"
         self.assertRaises(ValueError, ujson.decode, input)
 
     def test_decodeFloatingPointAdditionalTests(self):
@@ -809,6 +850,7 @@ class UltraJSONTests(unittest.TestCase):
         data = {"a": 1, "c": 1, "b": 1, "e": 1, "f": 1, "d": 1}
         sortedKeys = ujson.dumps(data, sort_keys=True)
         self.assertEqual(sortedKeys, '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1}')
+
 
 """
 def test_decodeNumericIntFrcOverflow(self):


### PR DESCRIPTION
* Run linting on GitHub Actions, using [pre-commit](https://pre-commit.com/) to group together and run linters:
  * pyupgrade
  * Black
  * Flake8 with a couple of handy plugins
  * And some other handy pre-commit linters
* Format code with Black
* Sort imports with isort
* Fix tests for Python 4
* Add a `.gitignore` from https://github.com/github/gitignore/blob/master/Python.gitignore
