### PR TITLE
Tests: Remove unused, unmaintained blist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade six blist
+          python -m pip install --upgrade six
           python -m pip install .
 
       - name: Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
 
 install:
   - pip install -U pip
-  - pip install -U six blist
+  - pip install -U six
   - pip install .
 
 script: python tests/tests.py

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -83,7 +83,6 @@ def results_output_table():
             platform.python_implementation(), sys.version.replace("\n", "")
         )
     )
-    print("- blist     : 1.3.6")
     print("- simplejson: 3.8.1")
     print("- ujson     : 1.34")
     print("- yajl      : 0.3.5")


### PR DESCRIPTION
No need to install it on the CIs, it was removed from test cases in https://github.com/ultrajson/ultrajson/commit/3a6ba52366329ed6d78ec4abbfab9080f1fd4aed.

* Last release: Mar 13, 2014 https://pypi.org/project/blist/1.3.6/
* Last commit:  Mar 13, 2014 https://github.com/DanielStutzbach/blist