### PR TITLE
Use Release Drafter to draft releases

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,66 @@
+# Default GitHub labels
+- color: d73a4a
+  description: "Something isn't working"
+  name: bug
+- color: cfd3d7
+  description: "This issue or pull request already exists"
+  name: duplicate
+- color: a2eeef
+  description: "New feature or request"
+  name: enhancement
+- color: 7057ff
+  description: "Good for newcomers"
+  name: good first issue
+- color: 008672
+  description: "Extra attention is needed"
+  name: help wanted
+- color: e4e669
+  description: "This doesn't seem right"
+  name: invalid
+- color: d876e3
+  description: "Further information is requested"
+  name: question
+- color: ffffff
+  description: "This will not be worked on"
+  name: wontfix
+
+# Keep a Changelog labels
+# https://keepachangelog.com/en/1.0.0/
+- color: 0e8a16
+  description: "For new features"
+  name: "changelog: Added"
+- color: af99e5
+  description: "For changes in existing functionality"
+  name: "changelog: Changed"
+- color: FFA500
+  description: "For soon-to-be removed features"
+  name: "changelog: Deprecated"
+- color: 00A800
+  description: "For any bug fixes"
+  name: "changelog: Fixed"
+- color: ff0000
+  description: "For now removed features"
+  name: "changelog: Removed"
+- color: 045aa0
+  description: "In case of vulnerabilities"
+  name: "changelog: Security"
+- color: fbca04
+  description: "Exclude PR from release draft"
+  name: "changelog: skip"
+
+# Other labels
+- color: fbca04
+  description: "Unit tests, linting, CI, etc."
+  name: testing
+- color: FFD43B
+  description: ""
+  name: Python 2
+- color: F25022
+  description: ""
+  name: Windows
+- color: e28acf
+  description: ""
+  name: documentation
+- color: caffaf
+  description: ""
+  name: release

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "$NEXT_PATCH_VERSION"
+
+categories:
+  - title: "Added"
+    labels:
+      - "changelog: Added"
+      - "enhancement"
+  - title: "Changed"
+    label: "changelog: Changed"
+  - title: "Deprecated"
+    label: "changelog: Deprecated"
+  - title: "Removed"
+    label: "changelog: Removed"
+  - title: "Fixed"
+    labels:
+      - "changelog: Fixed"
+      - "bug"
+  - title: "Security"
+    label: "changelog: Security"
+
+exclude-labels:
+  - "changelog: skip"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,15 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    if: github.repository == 'ultrajson/ultrajson'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next release notes as pull requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This uses GHA to set some labels that correspond to https://keepachangelog.com/en/1.0.0/

The https://github.com/micnncim/action-label-syncer action will sync them from a file to the issue labels.

The https://github.com/release-drafter/release-drafter action will automatically draft a [release](https://github.com/ultrajson/ultrajson/releases) based on merged PRs. Labels can be added to group PRs, or skip an entry.

The workflow will be:

PR: Pick a changelog label for it to go under that section, or no changelog label for it to go in the main section, or the skip label to omit it from the release.

Release: edit the draft, make any adjustments needed. Check the version number is good. It's set to bump patch version in config, so we'll need to put it to 2.0.0 for the next one. Then when ready, publish the draft. This will create a tag and also trigger a deploy to PyPI.