### PR TITLE
Fix Windows build and test Python 3.5-3.8 on Windows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          key: lint-pre-commit-v1-${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pre-commit-
+            lint-pre-commit-v1-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,20 @@ jobs:
 
       - name: macOS cache
         uses: actions/cache@v1
-        if: startsWith(matrix.os, 'macOS')
+        if: startsWith(matrix.os, 'macos')
         with:
           path: ~/Library/Caches/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Windows cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
           key:
             ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
             }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
-        os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-2019]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-2019]
+        exclude:
+          - {python-version: 2.7, os: windows-2019}
 
     steps:
       - uses: actions/checkout@v1

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -117,14 +117,6 @@ Dictates and limits how much stack space for buffers UltraJSON will use before r
 
     #define INLINE_PREFIX inline
 
-    #ifdef __GNUC__
-        #define LIKELY(x)       __builtin_expect(!!(x), 1)
-        #define UNLIKELY(x)     __builtin_expect(!!(x), 0)
-    #else
-        #define LIKELY(x)       (x)
-        #define UNLIKELY(x)     (x)
-    #endif
-
     typedef uint8_t JSUINT8;
     typedef uint16_t JSUTF16;
     typedef uint32_t JSUTF32;
@@ -132,6 +124,14 @@ Dictates and limits how much stack space for buffers UltraJSON will use before r
     typedef int64_t JSLONG;
 
     #define EXPORTFUNCTION
+#endif
+
+#ifdef __GNUC__
+    #define LIKELY(x)       __builtin_expect(!!(x), 1)
+    #define UNLIKELY(x)     __builtin_expect(!!(x), 0)
+#else
+    #define LIKELY(x)       (x)
+    #define UNLIKELY(x)     (x)
 #endif
 
 #if !(defined(__LITTLE_ENDIAN__) || defined(__BIG_ENDIAN__))

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -61,95 +61,95 @@ tree doesn't have cyclic references.
 
 // Max decimals to encode double floating point numbers with
 #ifndef JSON_DOUBLE_MAX_DECIMALS
-#define JSON_DOUBLE_MAX_DECIMALS 15
+    #define JSON_DOUBLE_MAX_DECIMALS 15
 #endif
 
 // Max recursion depth, default for encoder
 #ifndef JSON_MAX_RECURSION_DEPTH
-#define JSON_MAX_RECURSION_DEPTH 1024
+    #define JSON_MAX_RECURSION_DEPTH 1024
 #endif
 
 // Max recursion depth, default for decoder
 #ifndef JSON_MAX_OBJECT_DEPTH
-#define JSON_MAX_OBJECT_DEPTH 1024
+    #define JSON_MAX_OBJECT_DEPTH 1024
 #endif
 
 /*
 Dictates and limits how much stack space for buffers UltraJSON will use before resorting to provided heap functions */
 #ifndef JSON_MAX_STACK_BUFFER_SIZE
-#define JSON_MAX_STACK_BUFFER_SIZE 1024
+    #define JSON_MAX_STACK_BUFFER_SIZE 1024
 #endif
 
 #ifdef _WIN32
 
-typedef __int64 JSINT64;
-typedef unsigned __int64 JSUINT64;
+    typedef __int64 JSINT64;
+    typedef unsigned __int64 JSUINT64;
 
-typedef __int32 JSINT32;
-typedef unsigned __int32 JSUINT32;
-typedef unsigned __int8 JSUINT8;
-typedef unsigned __int16 JSUTF16;
-typedef unsigned __int32 JSUTF32;
-typedef __int64 JSLONG;
+    typedef __int32 JSINT32;
+    typedef unsigned __int32 JSUINT32;
+    typedef unsigned __int8 JSUINT8;
+    typedef unsigned __int16 JSUTF16;
+    typedef unsigned __int32 JSUTF32;
+    typedef __int64 JSLONG;
 
-#define EXPORTFUNCTION __declspec(dllexport)
+    #define EXPORTFUNCTION __declspec(dllexport)
 
-#define FASTCALL_MSVC __fastcall
-#define FASTCALL_ATTR
-#define INLINE_PREFIX __inline
+    #define FASTCALL_MSVC __fastcall
+    #define FASTCALL_ATTR
+    #define INLINE_PREFIX __inline
 
 #else
 
-#include <stdint.h>
-typedef int64_t JSINT64;
-typedef uint64_t JSUINT64;
+    #include <stdint.h>
+    typedef int64_t JSINT64;
+    typedef uint64_t JSUINT64;
 
-typedef int32_t JSINT32;
-typedef uint32_t JSUINT32;
+    typedef int32_t JSINT32;
+    typedef uint32_t JSUINT32;
 
-#define FASTCALL_MSVC
+    #define FASTCALL_MSVC
 
-#if !defined __x86_64__
-#define FASTCALL_ATTR __attribute__((fastcall))
-#else
-#define FASTCALL_ATTR
-#endif
+    #if !defined __x86_64__
+        #define FASTCALL_ATTR __attribute__((fastcall))
+    #else
+        #define FASTCALL_ATTR
+    #endif
 
-#define INLINE_PREFIX inline
+    #define INLINE_PREFIX inline
 
-#ifdef __GNUC__
-#define LIKELY(x)       __builtin_expect(!!(x), 1)
-#define UNLIKELY(x)     __builtin_expect(!!(x), 0)
-#else
-#define LIKELY(x)       (x)
-#define UNLIKELY(x)     (x)
-#endif
+    #ifdef __GNUC__
+        #define LIKELY(x)       __builtin_expect(!!(x), 1)
+        #define UNLIKELY(x)     __builtin_expect(!!(x), 0)
+    #else
+        #define LIKELY(x)       (x)
+        #define UNLIKELY(x)     (x)
+    #endif
 
-typedef uint8_t JSUINT8;
-typedef uint16_t JSUTF16;
-typedef uint32_t JSUTF32;
+    typedef uint8_t JSUINT8;
+    typedef uint16_t JSUTF16;
+    typedef uint32_t JSUTF32;
 
-typedef int64_t JSLONG;
+    typedef int64_t JSLONG;
 
-#define EXPORTFUNCTION
+    #define EXPORTFUNCTION
 #endif
 
 #if !(defined(__LITTLE_ENDIAN__) || defined(__BIG_ENDIAN__))
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define __LITTLE_ENDIAN__
-#else
+    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        #define __LITTLE_ENDIAN__
+    #else
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define __BIG_ENDIAN__
-#endif
+    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        #define __BIG_ENDIAN__
+    #endif
 
 #endif
 
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-#error "Endianess not supported"
+    #error "Endianess not supported"
 #endif
 
 enum JSTYPES

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -149,7 +149,7 @@ Dictates and limits how much stack space for buffers UltraJSON will use before r
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-    #error "Endianess not supported"
+    #error "Endianness not supported"
 #endif
 
 enum JSTYPES


### PR DESCRIPTION
Fixes #369.

This block, added in https://github.com/ultrajson/ultrajson/commit/ac4637fbc4e72bd59f221d9bba19127820d21023:

```h
#ifdef __GNUC__
#define LIKELY(x)       __builtin_expect(!!(x), 1)
#define UNLIKELY(x)     __builtin_expect(!!(x), 0)
#else
#define LIKELY(x)       (x)
#define UNLIKELY(x)     (x)
#endif
```

It was defined in the `else` condition of `#ifdef _WIN32`, meaning it wasn't actually included in Windows builds at all.

* Move it out of that `#ifdef` block so it is included in Windows builds.

* Also indent the `#ifdef`s, hopefully to make this less likely to repeat.

* And we can now test Python 3.5-3.8 on Windows on GHA. (Python 2.7 is still failing, didn't look into it.)

* Finally, unrelated: set a version number in the pre-commit cache for https://github.com/pre-commit/pre-commit/issues/1353.