### PR TITLE
Add script to build wheels with manylinux 

### DIFF
--- a/scripts/build-manylinux.py
+++ b/scripts/build-manylinux.py
@@ -34,19 +34,16 @@ def main():
 
         if subprocess.call(
             (
-                "docker",
-                "run",
-                "--rm",
+                # fmt: off
+                "docker", "run", "--rm",
                 # so files are not root-owned
-                "--user",
-                f"{os.getuid()}:{os.getgid()}",
-                "--volume",
-                f'{os.path.abspath("dist")}:/dist:rw',
+                "--user", f"{os.getuid()}:{os.getgid()}",
+                "--volume", f'{os.path.abspath("dist")}:/dist:rw',
                 "quay.io/pypa/manylinux1_x86_64:latest",
-                "bash",
-                "-euxc",
+                "bash", "-euxc",
                 f"{pip} wheel -w /tmp/wheels --no-deps {pkg} && "
                 f"auditwheel repair -w /dist /tmp/wheels/*.whl",
+                # fmt: on
             )
         ):
             return 1

--- a/scripts/build-manylinux.py
+++ b/scripts/build-manylinux.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import argparse
+import os.path
+import re
+import subprocess
+
+VERSION = re.compile(r":: Python :: (\d\.\d)$")
+
+EXES = []
+with open("setup.py") as f:
+    for line in f:
+        match = VERSION.search(line)
+        if match:
+            major_s, minor_s = match[1].split(".")
+            major, minor = int(major_s), int(minor_s)
+            if (major, minor) == (2, 7):
+                EXES.extend(("cp27-cp27mu", "cp27-cp27m"))
+            elif (major, minor) < (3, 8):
+                EXES.append(f"cp{major}{minor}-cp{major}{minor}m")
+            else:
+                EXES.append(f"cp{major}{minor}-cp{major}{minor}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+
+    pkg = f"ujson=={args.version}"
+
+    os.makedirs("dist", exist_ok=True)
+    for exe in EXES:
+        pip = f"/opt/python/{exe}/bin/pip"
+
+        if subprocess.call(
+            (
+                "docker",
+                "run",
+                "--rm",
+                # so files are not root-owned
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",
+                "--volume",
+                f'{os.path.abspath("dist")}:/dist:rw',
+                "quay.io/pypa/manylinux1_x86_64:latest",
+                "bash",
+                "-euxc",
+                f"{pip} wheel -w /tmp/wheels --no-deps {pkg} && "
+                f"auditwheel repair -w /dist /tmp/wheels/*.whl",
+            )
+        ):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Same script as https://github.com/ultrajson/ultrajson/issues/219#issuecomment-598359006, but Blackened.

Example:

```console
$ python scripts/build-manylinux.py 2.0.1
+ /opt/python/cp27-cp27mu/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp27-cp27mu-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp27-cp27mu-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp27-cp27mu-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp27-cp27mu-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp27-cp27mu-manylinux1_x86_64.whl
+ /opt/python/cp27-cp27m/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp27-cp27m-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp27-cp27m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp27-cp27m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp27-cp27m-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp27-cp27m-manylinux1_x86_64.whl
+ /opt/python/cp35-cp35m/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp35-cp35m-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp35-cp35m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp35-cp35m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp35-cp35m-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp35-cp35m-manylinux1_x86_64.whl
+ /opt/python/cp36-cp36m/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp36-cp36m-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp36-cp36m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp36-cp36m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp36-cp36m-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp36-cp36m-manylinux1_x86_64.whl
+ /opt/python/cp37-cp37m/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp37-cp37m-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp37-cp37m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp37-cp37m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp37-cp37m-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp37-cp37m-manylinux1_x86_64.whl
+ /opt/python/cp38-cp38/bin/pip wheel -w /tmp/wheels --no-deps ujson==2.0.1
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting ujson==2.0.1
  Downloading https://files.pythonhosted.org/packages/a5/5d/8c7d86226c20dc9205451fa0cd3ccc4982e339981c31f87974853754edfc/ujson-2.0.1.tar.gz (7.1MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: ujson
  Building wheel for ujson (PEP 517): started
  Building wheel for ujson (PEP 517): finished with status 'done'
  Stored in directory: /tmp/wheels
Successfully built ujson
WARNING: The directory '/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ auditwheel repair -w /dist /tmp/wheels/ujson-2.0.1-cp38-cp38-linux_x86_64.whl
INFO:auditwheel.main_repair:Repairing ujson-2.0.1-cp38-cp38-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux1_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp38-cp38-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp38-cp38-manylinux1_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /dist/ujson-2.0.1-cp38-cp38-manylinux1_x86_64.whl
```
```console
$ ls -l dist
total 2072
-rw-r--r--  1 hugo  staff  173007 12 Mar 23:22 ujson-2.0.1-cp27-cp27m-manylinux1_x86_64.whl
-rw-r--r--  1 hugo  staff  173000 12 Mar 23:21 ujson-2.0.1-cp27-cp27mu-manylinux1_x86_64.whl
-rw-r--r--  1 hugo  staff  175427 12 Mar 23:22 ujson-2.0.1-cp35-cp35m-manylinux1_x86_64.whl
-rw-r--r--  1 hugo  staff  175419 12 Mar 23:22 ujson-2.0.1-cp36-cp36m-manylinux1_x86_64.whl
-rw-r--r--  1 hugo  staff  175404 12 Mar 23:23 ujson-2.0.1-cp37-cp37m-manylinux1_x86_64.whl
-rw-r--r--  1 hugo  staff  177529 12 Mar 23:24 ujson-2.0.1-cp38-cp38-manylinux1_x86_64.whl
```

Thanks @asottile!
