### PR TITLE
Decrease dict key reference.

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -263,7 +263,9 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
 
   if (PyUnicode_Check(GET_TC(tc)->itemName))
   {
+    itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
+    Py_DECREF(itemNameTmp);
   }
   else
   if (!PyString_Check(GET_TC(tc)->itemName))

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -239,9 +239,7 @@ static char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
 {
-#if PY_MAJOR_VERSION >= 3
   PyObject* itemNameTmp;
-#endif
 
   if (GET_TC(tc)->itemName)
   {

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -239,6 +239,17 @@ def test_encode_dict_values_ref_counting():
     assert ref_count == sys.getrefcount(value)
 
 
+def test_encode_dict_key_ref_counting():
+    import gc
+
+    gc.collect()
+    key = "key"
+    data = {key: "abc"}
+    ref_count = sys.getrefcount(key)
+    ujson.dumps(data)
+    assert ref_count == sys.getrefcount(key)
+
+
 def test_encode_to_utf8():
     test_input = b"\xe6\x97\xa5\xd1\x88"
     if not six.PY2:


### PR DESCRIPTION
Changeset c9f8318 changed how dict items are iterated. As a consequence, a reference to a dict key remains - clear it.

Fixes #392 

Changes proposed in this pull request:

* Fix memory leak

Note: I'm not very familiar with python c-api, and I don't understand why the mentioned changeset triggered the bug.