### PR TITLE
Fix TestPyPI deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v1


### PR DESCRIPTION
Changes proposed in this pull request:

* Looks like a recent change in the GHA checkout means tags aren't available
* This means setuptools-scm couldn't calculate a version and defaulted to 0.1.dev1 which had already been uploaded, and failed:
```
Uploading ujson-0.1.dev1.tar.gz

  0%|          | 0.00/6.81M [00:00<?, ?B/s]
  3%|▎         | 176k/6.81M [00:00<00:03, 1.75MB/s]
 65%|██████▌   | 4.43M/6.81M [00:00<00:01, 2.43MB/s]
 88%|████████▊ | 5.98M/6.81M [00:00<00:00, 3.11MB/s]
100%|██████████| 6.81M/6.81M [00:01<00:00, 3.90MB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: File already exists. See https://test.pypi.org/help/#file-name-reuse for url: https://test.pypi.org/legacy/
```
* Didn't affect tag builds that deploy to live PyPI
* Fix by first fetching the tags, per https://github.com/actions/checkout/#Fetch-all-tags
