### PR TITLE
Drop legacy distutils in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max_line_length = 88
 
 [tool:isort]
-known_third_party = pytest,six,ujson
+known_third_party = pytest,setuptools,six,ujson
 force_grid_wrap = 0
 include_trailing_comma = True
 line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
 import os.path
 import re
 from glob import glob
+
+from setuptools import Extension, setup
 
 CLASSIFIERS = """
 Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Distutils is not recommended for use and unnecessary for modern Python environments. Use only setuptools instead. From [docs.python.org/3/library/distutils.html](https://docs.python.org/3/library/distutils.html):

> Most Python users will not want to use this module directly, but instead use the cross-version tools maintained by the Python Packaging Authority. In particular, setuptools is an enhanced alternative to distutils ...
> The recommended pip installer runs all setup.py scripts with setuptools, even if the script itself only imports distutils. Refer to the Python Packaging User Guide for more information.
