### PR TITLE
Specify setuptools_scm config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
 [tool.black]
 target_version = ["py27"]


### PR DESCRIPTION
This provides multiple advantages:

- It is the recommended way of using setuptools_scm
- It makes it easier for tools to find this dependency and therefore
  build in a sandbox

The previous behavior is still left in place to support older version
of setuptools and pip that do not support PEP 517

Fixes #380 
