### PR TITLE
Make ujson PEP 384 compliant

### DIFF
--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -172,7 +172,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
 
   dconv_s2d_init(DCONV_S2D_ALLOW_TRAILING_JUNK, 0.0, 0.0, "Infinity", "NaN");
 
-  ret = JSON_DecodeObject(&decoder, PyBytes_AS_STRING(sarg), PyBytes_GET_SIZE(sarg));
+  ret = JSON_DecodeObject(&decoder, PyBytes_AsString(sarg), PyBytes_Size(sarg));
 
   dconv_s2d_free();
 


### PR DESCRIPTION
Add a function to check if an object is of type `decimal.Decimal`.
Since that type was previously cached as a static variable, this commit
makes it a member of the module state instead. Add the associated module
state machinery.

Also check if the module exists before creating it anew in the init
function.

See PEP 384 (Defining a Stable ABI):
https://www.python.org/dev/peps/pep-0384/ and PEP 3121 (Extension Module
Initialization and Finalization):
https://www.python.org/dev/peps/pep-3121/