### PR TITLE
Build Linux wheels in parallel

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -73,9 +73,10 @@ jobs:
         docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
         docker run -e PLAT=manylinux1_i686 -v `pwd`:/io quay.io/pypa/manylinux1_i686 /io/scripts/build-manylinux-wheels.sh
 
-    - uses: actions/upload-artifact@v2
+    - name: Upload as build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        name: Upload as build artifacts
+        name: wheels
         path: dist/*.whl
 
     - name: Publish package to PyPI

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -22,15 +22,21 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: 3.8
+            wheel: aarch64
+          - os: ubuntu-latest
+            python-version: 3.8
+            wheel: x86
 
     steps:
     - uses: actions/checkout@v2
     - run: |
         git fetch --prune --unshallow
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Docker Buildx
       if: matrix.os == 'ubuntu-latest'
       id: buildx
@@ -38,7 +44,6 @@ jobs:
       with:
         buildx-version: latest
         qemu-version: latest
-
 
     - name: Install dependencies
       run: |
@@ -55,7 +60,7 @@ jobs:
       run: python setup.py -q bdist_wheel
 
     - name: Build ManyLinux2014_aarch64 wheels
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.wheel == 'aarch64'
       run: |
         docker buildx build --platform linux/arm64 \
         -t ujson_aarch64 --output tmpwheelhouse -f scripts/Dockerfile_aarch64 .
@@ -63,7 +68,7 @@ jobs:
         mv tmpwheelhouse/wheelhouse/*.whl dist/
 
     - name: Build x86 Linux wheels
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.wheel == 'x86'
       run: |
         docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
         docker run -e PLAT=manylinux1_i686 -v `pwd`:/io quay.io/pypa/manylinux1_i686 /io/scripts/build-manylinux-wheels.sh


### PR DESCRIPTION
Changes proposed in this pull request:

* Follow up to https://github.com/ultrajson/ultrajson/pull/422
* The manylinux2014_aarch64 wheel build takes between 9-14 minutes 
* The x86 Linux wheels take 3-4 minutes

![image](https://user-images.githubusercontent.com/1324225/92498967-f7891000-f203-11ea-9e87-3491abde1a4d.png)

* Rather than doing those in serial, add them to the matrix so they run in parallel. They setup/finalise bits are quick, so they work well in parallel.

![image](https://user-images.githubusercontent.com/1324225/92500986-a1699c00-f206-11ea-8e1a-93efed0dc4b8.png)

and

![image](https://user-images.githubusercontent.com/1324225/92501041-afb7b800-f206-11ea-9959-93e535194a54.png)


* Whilst we're here, let's also rename the GH build artifacts to `wheels.zip` instead of `Upload as build artifacts.zip`
