### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,28 +2,27 @@ name: Lint
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: pip cache
+      - name: Cache
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: lint-pip-${{ hashFiles('**/setup.py') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key:
+            lint-${{ hashFiles('**/setup.py') }}-${{
+            hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pip-
-
-      - name: pre-commit cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: lint-pre-commit-v1-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            lint-pre-commit-v1-
+            lint-
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -37,3 +36,5 @@ jobs:
 
       - name: Lint
         run: pre-commit run --all-files
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,9 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          python -m pip install -U "pip>=20.1"
           echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: pip cache
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
           - { python-version: "pypy3", os: ubuntu-18.04 }
           - { python-version: "pypy3", os: ubuntu-16.04 }
           # Dev versions
-          - { python-version: "3.10-dev", os: ubuntu-18.04 }
+          # 3.10-dev blocked by:
+          # AssertionError: would build wheel with unsupported tag ('cp310', 'cp310', 'linux_x86_64')
+          #- { python-version: "3.10-dev", os: ubuntu-18.04 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8"]
+        python-version: [ "3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-2019]
         include:
           # PyPy3
           - { python-version: "pypy3", os: ubuntu-18.04 }
           - { python-version: "pypy3", os: ubuntu-16.04 }
           # Dev versions
-          - { python-version: "3.9-dev", os: ubuntu-18.04 }
+          - { python-version: "3.10-dev", os: ubuntu-18.04 }
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3 :: Only
 """
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Python 3.9 has been released: https://blog.python.org/2020/10/python-390-is-now-available-and-you-can.html
* ~Let's see how the wheel building gets on after merge, we may need to wait for some dependencies~
  * ~Edit: temporarily testing deploy from this feature branch~
  * Edit 2: will back out wheel changes from this PR and deal with it separately
