### PR TITLE
Fix UnicodeDecodeError on arm64/aarch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ module1 = Extension(
 )
 
 
-with open("README.rst") as f:
+with open("README.rst", encoding="utf-8") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
Fixes https://github.com/ultrajson/ultrajson/issues/434

Changes proposed in this pull request:

* The README now contains non-ASCII characters (https://github.com/ultrajson/ultrajson/pull/427)
* Therefore explicitly specify UTF-8 when opening the file

The docs https://docs.python.org/3/library/functions.html#open say:

>  In text mode, if encoding is not specified the encoding used is platform dependent: `locale.getpreferredencoding(False)` is called to get the current locale encoding.

On a Mac, it's `UTF-8`, no problem.

On arm64/aarch64, it's `ANSI_X3.4-1968`.
