### PR TITLE
Travis CI: Test on 3.9 final, remove 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ arch:
   - arm64
   - s390x
 
+# Only test oldest and newest supported versions
 python:
   - "3.6"
-  - "3.8"
   - "3.9"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ arch:
 python:
   - "3.6"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
Fixes #437

Changes proposed in this pull request:

* use Python 3.9 final in CI config

came here from this issue:
https://github.com/hugovk/pypistats/issues/181