### PR TITLE
Fix dealing with None types

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -258,7 +258,9 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
   {
     if (UNLIKELY(GET_TC(tc)->itemName == Py_None))
     {
-      GET_TC(tc)->itemName = PyUnicode_FromString("null");
+      itemNameTmp = PyUnicode_FromString("null");
+      GET_TC(tc)->itemName = PyUnicode_AsUTF8String(itemNameTmp);
+      Py_DECREF(Py_None);
       return 1;
     }
 
@@ -537,17 +539,17 @@ static void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObject
     return;
   }
   else
-  if (PyFloat_Check(obj) || object_is_decimal_type(obj))
-  {
-    PRINTMARK();
-    pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;
-    return;
-  }
-  else
   if (obj == Py_None)
   {
     PRINTMARK();
     tc->type = JT_NULL;
+    return;
+  }
+  else
+  if (PyFloat_Check(obj) || object_is_decimal_type(obj))
+  {
+    PRINTMARK();
+    pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;
     return;
   }
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -806,6 +806,11 @@ def test_reject_bytes_false():
     assert ujson.dumps(data, reject_bytes=False) == '{"a":"b"}'
 
 
+def test_encode_none_key():
+    data = {None: None}
+    assert ujson.dumps(data) == '{"null":null}'
+
+
 """
 def test_decode_numeric_int_frc_overflow():
 input = "X.Y"


### PR DESCRIPTION
Fixes #425

Changes proposed in this pull request:

* The code checking for whether or not a value is a decimal type doesn't deal with `None` types well so I moved the check for `None` before `object_is_decimal_type`
* Returning a unicode "null" was incompatible with later code which expected dict keys to be in encoded UTF8 format. Now the itemName is set to a UTF8 "nulll" in the UNLIKELY event that a key has the value `None`.