### PR TITLE
Fix #429: Make empty dict/list indented serialization match stdlib json

### DIFF
--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -665,7 +665,6 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       count = 0;
 
       Buffer_AppendCharUnchecked (enc, '[');
-      Buffer_AppendIndentNewlineUnchecked (enc);
 
       while (enc->iterNext(obj, &tc))
       {
@@ -675,8 +674,8 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 #ifndef JSON_NO_EXTRA_WHITESPACE
           Buffer_AppendCharUnchecked (enc, ' ');
 #endif
-          Buffer_AppendIndentNewlineUnchecked (enc);
         }
+        Buffer_AppendIndentNewlineUnchecked (enc);
 
         iterObj = enc->iterGetValue(obj, &tc);
 
@@ -687,8 +686,11 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       }
 
       enc->iterEnd(obj, &tc);
-      Buffer_AppendIndentNewlineUnchecked (enc);
-      Buffer_AppendIndentUnchecked (enc, enc->level);
+
+      if (count > 0) {
+        Buffer_AppendIndentNewlineUnchecked (enc);
+        Buffer_AppendIndentUnchecked (enc, enc->level);
+      }
       Buffer_AppendCharUnchecked (enc, ']');
       break;
     }
@@ -698,7 +700,6 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       count = 0;
 
       Buffer_AppendCharUnchecked (enc, '{');
-      Buffer_AppendIndentNewlineUnchecked (enc);
 
       while ((res = enc->iterNext(obj, &tc)))
       {
@@ -716,8 +717,8 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 #ifndef JSON_NO_EXTRA_WHITESPACE
           Buffer_AppendCharUnchecked (enc, ' ');
 #endif
-          Buffer_AppendIndentNewlineUnchecked (enc);
         }
+        Buffer_AppendIndentNewlineUnchecked (enc);
 
         iterObj = enc->iterGetValue(obj, &tc);
         objName = enc->iterGetName(obj, &tc, &szlen);
@@ -729,8 +730,11 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       }
 
       enc->iterEnd(obj, &tc);
-      Buffer_AppendIndentNewlineUnchecked (enc);
-      Buffer_AppendIndentUnchecked (enc, enc->level);
+
+      if (count > 0) {
+        Buffer_AppendIndentNewlineUnchecked (enc);
+        Buffer_AppendIndentUnchecked (enc, enc->level);
+      }
       Buffer_AppendCharUnchecked (enc, '}');
       break;
     }

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -249,11 +249,21 @@ def test_encode_to_utf8():
     assert dec == json.loads(enc)
 
 
-def test_encode_indent():
-    test_input = '{\n    "obj": 31337\n}'
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        '{\n    "obj": 31337\n}',
+        "{}",
+        "[]",
+        '{\n    "a": {}\n}',
+        "[\n    []\n]",
+    ],
+)
+def test_encode_indent(test_input):
     obj = ujson.decode(test_input)
     output = ujson.encode(obj, indent=4)
     assert test_input == output
+    assert output == json.dumps(obj, indent=4)
 
 
 def test_decode_from_unicode():


### PR DESCRIPTION
Previously, we'd output a couple of new lines between the start and end of the object, whereas the stdlib doesn't bother with whitespace if they're empty.

In my testing, the only difference in indented serialization now is float representation.

Fixes #429

Changes proposed in this pull request:

* Serializing an empty dict, with indentation, now outputs `{}`, which matches stdlib
* Serializing an empty list, with indentation, now outputs `[]`, which matches stdlib
