### PR TITLE
Remove explicit handling of manylinux platform tag

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -70,8 +70,8 @@ jobs:
     - name: Build x86 Linux wheels
       if: matrix.wheel == 'x86'
       run: |
-        docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
-        docker run -e PLAT=manylinux1_i686 -v `pwd`:/io quay.io/pypa/manylinux1_i686 /io/scripts/build-manylinux-wheels.sh
+        docker run -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
+        docker run -v `pwd`:/io quay.io/pypa/manylinux1_i686 /io/scripts/build-manylinux-wheels.sh
 
     - name: Upload as build artifacts
       uses: actions/upload-artifact@v2

--- a/scripts/Dockerfile_aarch64
+++ b/scripts/Dockerfile_aarch64
@@ -1,6 +1,5 @@
 FROM quay.io/pypa/manylinux2014_aarch64 as build
 
-ENV PLAT=manylinux2014_aarch64
 RUN mkdir -p /io/
 COPY . /io/
 WORKDIR /io/

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -4,10 +4,7 @@ set -e -x
 # This is to be run by Docker inside a Docker image.
 # You can test it locally on a Linux machine by installing Docker and running from this
 # repo's root:
-# $ docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
-
-# The -e just defines an environment variable PLAT=[docker name] inside the Docker:
-# auditwheel can't detect the Docker name automatically.
+# $ docker run -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
 
 # The -v gives a directory alias for passing files in and out of the Docker.
 # (/io is arbitrary). E.g the setup.py script can be accessed in the Docker via
@@ -39,5 +36,5 @@ done
 mkdir -p /io/dist/
 
 for whl in /io/temp-wheels/*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/dist/
+    auditwheel repair "$whl" -w /io/dist/
 done


### PR DESCRIPTION
Not the most exciting pull request. Slightly simplify building wheels for Linux.

The manylinux docker images now have an `$AUDITWHEEL_PLAT` environment
variable baked into them which auditwheel detects automatically.
Therefore we no longer need to remind each image which image they are.

Just to prove that it still works: [Here is a CI run](https://github.com/bwoodsend/ultrajson/actions/runs/596499418).