### PR TITLE
ENH: Add `drop_none` keyword that will prevent writing `null` items

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -258,6 +258,10 @@ typedef struct __JSONObjectEncoder
   int sortKeys;
 
   /*
+  If true, None values are not exported. */
+  int dropNone;
+
+  /*
   Configuration for spaces of indent */
   int indent;
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -740,7 +740,7 @@ static char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-  static char *kwlist[] = { "obj", "ensure_ascii", "encode_html_chars", "escape_forward_slashes", "sort_keys", "indent", "allow_nan", "reject_bytes", NULL };
+  static char *kwlist[] = { "obj", "ensure_ascii", "encode_html_chars", "escape_forward_slashes", "sort_keys", "drop_none", "indent", "allow_nan", "reject_bytes", NULL };
 
   char buffer[65536];
   char *ret;
@@ -751,6 +751,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *oencodeHTMLChars = NULL;
   PyObject *oescapeForwardSlashes = NULL;
   PyObject *osortKeys = NULL;
+  PyObject *odropNone = NULL;
   int allowNan = -1;
   int orejectBytes = -1;
 
@@ -776,16 +777,16 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     0, //encodeHTMLChars
     1, //escapeForwardSlashes
     0, //sortKeys
+    0, //dropNone
     0, //indent
     1, //allowNan
     1, //rejectBytes
     NULL, //prv
   };
 
-
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOiii", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &encoder.indent, &allowNan, &orejectBytes))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOOiii", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &odropNone, &encoder.indent, &allowNan, &orejectBytes))
   {
     return NULL;
   }
@@ -808,6 +809,11 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   if (osortKeys != NULL && PyObject_IsTrue(osortKeys))
   {
     encoder.sortKeys = 1;
+  }
+
+  if (odropNone != NULL && PyObject_IsTrue(odropNone))
+  {
+    encoder.dropNone = 1;
   }
 
   if (allowNan != -1)

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -55,6 +55,7 @@ PyObject* JSONFileToObj(PyObject* self, PyObject *args, PyObject *kwargs);
 #define ENCODER_HELP_TEXT "Use ensure_ascii=false to output UTF-8. " \
     "Set encode_html_chars=True to encode < > & as unicode escape sequences. "\
     "Set escape_forward_slashes=False to prevent escaping / characters." \
+    "Set drop_none=True to drop None values." \
     "Set allow_nan=False to raise an exception when NaN or Inf would be serialized." \
     "Set reject_bytes=True to raise TypeError on bytes."
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -827,6 +827,10 @@ def test_encode_none_key():
     data = {None: None}
     assert ujson.dumps(data) == '{"null":null}'
 
+def test_drop_none():
+    data = [{"key1": "value", "key2": None}, 81, None, {"test": None}]
+    assert ujson.dumps(data, drop_none=False) == '[{"key1":"value","key2":null},81,null,{"test":null}]'
+    assert ujson.dumps(data, drop_none=True) == '[{"key1":"value"},81]'
 
 """
 def test_decode_numeric_int_frc_overflow():

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -827,10 +827,15 @@ def test_encode_none_key():
     data = {None: None}
     assert ujson.dumps(data) == '{"null":null}'
 
+
 def test_drop_none():
     data = [{"key1": "value", "key2": None}, 81, None, {"test": None}]
-    assert ujson.dumps(data, drop_none=False) == '[{"key1":"value","key2":null},81,null,{"test":null}]'
+    assert (
+        ujson.dumps(data, drop_none=False)
+        == '[{"key1":"value","key2":null},81,null,{"test":null}]'
+    )
     assert ujson.dumps(data, drop_none=True) == '[{"key1":"value"},81]'
+
 
 """
 def test_decode_numeric_int_frc_overflow():


### PR DESCRIPTION
__Changes proposed in this pull request:__ New `drop_none` parameter for `dumps()` function.

The `drop_none` parameter defaults to `False`. If set to `True`, `None` values in Python input, corresponding to `null` values in JSON format, will not be returned by `dumps()`.

__Important note:__ Code is not working yet.

The intention of this PR is to get feedback on whether or not such a functionality is within the scope of the `ultrajson` package, and, if so, decide what would be the best approach to do it.

The changes I made sort of implement this functionality, but I stopped fixing it when I realized that more refactoring would be necessary to fix issues such as leftover commas and empty objects that might be created when setting `drop_none=True`.

As an example, see the (failing) tests I wrote that show what I was aiming at:

```python
ujson.dumps([{"key1": "value", "key2": None}, 81, None, {"test": None}], drop_none=True)
# should return: '[{"key1":"value"},81]'
# returns: '[{"key1":"value",},81,,{}]'
```

I'm looking forward for your feedback.