### PR TITLE
Switch shebang for the manylinux-wheels script

### DIFF
--- a/scripts/Dockerfile_aarch64
+++ b/scripts/Dockerfile_aarch64
@@ -4,7 +4,7 @@ RUN mkdir -p /io/
 COPY . /io/
 WORKDIR /io/
 
-RUN ./scripts/build-manylinux-wheels.sh
+RUN bash ./scripts/build-manylinux-wheels.sh
 
 FROM scratch as release
 COPY --from=build /io/dist /wheelhouse

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -x
 
 # This is to be run by Docker inside a Docker image.


### PR DESCRIPTION
Fixes #464.

A whole day of scowling at it to discover that making this rather pathetic change somehow fixes it. Docker buildx is new and it is quite normal for its error messages to be odd but this one makes no sense for so many different reasons.

Some history:

- I couldn't reproduce the error locally - it all runs perfectly fine on my machine.
- The failure is almost certainly a change to the build environment although I can't tell what. Diffing the logs for the passing and failing runs I saw that:
  * The manylinux2014_aarch64 image had changed - but pinning it back to the old version fixed nothing
  * The Linux kernel version had updated - this is not exactly configurable
  * Docker-compose, buildx and qemu where all identical

So I've still got no idea what changed to cause the error to surface now and if it's likely to resurface. [Here](https://github.com/bwoodsend/ultrajson/actions/runs/929884617) is a working build log. If that plays up again, I've found that ditching the dockerfile and replacing the `docker buildx build` command with just another `docker run` (like the other architectures) also works (again for no reason that I can see).