### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -70,8 +70,8 @@ jobs:
     - name: Build x86 Linux wheels
       if: matrix.wheel == 'x86'
       run: |
-        docker run -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
-        docker run -v `pwd`:/io quay.io/pypa/manylinux1_i686 /io/scripts/build-manylinux-wheels.sh
+        docker run -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 /io/scripts/build-manylinux-wheels.sh
+        docker run -v `pwd`:/io quay.io/pypa/manylinux2014_i686 /io/scripts/build-manylinux-wheels.sh
 
     - name: Upload as build artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         include:
           - os: ubuntu-latest
             python-version: 3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.6", "3.7", "3.8", "3.9"]
-        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
         include:
           # PyPy3
+          - { python-version: "pypy3", os: ubuntu-20.04 }
           - { python-version: "pypy3", os: ubuntu-18.04 }
-          - { python-version: "pypy3", os: ubuntu-16.04 }
           # Dev versions
           - { python-version: "3.10-dev", os: ubuntu-20.04 }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9"]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
         include:
           # PyPy3
           - { python-version: "pypy3", os: ubuntu-20.04 }
           - { python-version: "pypy3", os: ubuntu-18.04 }
-          # Dev versions
-          - { python-version: "3.10-dev", os: ubuntu-20.04 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
-        include:
-          # PyPy3
-          - { python-version: "pypy3", os: ubuntu-20.04 }
-          - { python-version: "pypy3", os: ubuntu-18.04 }
+        exclude:
+          - { python-version: "pypy3", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -4,11 +4,11 @@ set -e -x
 # This is to be run by Docker inside a Docker image.
 # You can test it locally on a Linux machine by installing Docker and running from this
 # repo's root:
-# $ docker run -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
+# $ docker run -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 /io/scripts/build-manylinux-wheels.sh
 
 # The -v gives a directory alias for passing files in and out of the Docker.
 # (/io is arbitrary). E.g the setup.py script can be accessed in the Docker via
-# /io/setup.py quay.io/pypa/manylinux1_x86_64 is the full Docker image name. Docker
+# /io/setup.py quay.io/pypa/manylinux2014_x86_64 is the full Docker image name. Docker
 # downloads it automatically.
 
 # The last argument is a shell command that the Docker will execute. Filenames must be
@@ -22,7 +22,7 @@ mkdir -p /io/temp-wheels
 # Clean out any old existing wheels.
 find /io/temp-wheels/ -type f -delete
 
-for PYBIN in /opt/python/cp3[6789]*/bin; do
+for PYBIN in /opt/python/cp3[678910]*/bin; do
     "${PYBIN}/pip" install -q -U setuptools wheel pytest --cache-dir /io/pip-cache
     (cd /io/ && "${PYBIN}/python" -m pip install .)
     (cd /io/ && "${PYBIN}/python" -m pytest)

--- a/scripts/build-manylinux.py
+++ b/scripts/build-manylinux.py
@@ -37,7 +37,7 @@ def main():
                 # so files are not root-owned
                 "--user", f"{os.getuid()}:{os.getgid()}",
                 "--volume", f'{os.path.abspath("dist")}:/dist:rw',
-                "quay.io/pypa/manylinux1_x86_64:latest",
+                "quay.io/pypa/manylinux2014_x86_64:latest",
                 "bash", "-euxc",
                 f"{pip} wheel -w /tmp/wheels --no-deps {pkg} && "
                 f"auditwheel repair -w /dist /tmp/wheels/*.whl",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3 :: Only
 """
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add Python 3.10 classifier
* Wheel builder: Update manylinux1 to manylinux2014 to build Python 3.10 wheels
* Test Python 3.10-dev on all OS
* Test PyPy3 also on Windows

TODO:

* [ ] Adjust required branch status checks before merge.