### PR TITLE
Build wheels for musl Linux (musllinux_1_1_x86_64)

### DIFF
--- a/.github/workflows/deploy-wheels-linux.yml
+++ b/.github/workflows/deploy-wheels-linux.yml
@@ -18,6 +18,7 @@ jobs:
             "manylinux2014_aarch64",
             "manylinux2014_i686",
             "manylinux2014_x86_64",
+            "musllinux_1_1_x86_64",
         ]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         include:


### PR DESCRIPTION
Users on musl based Linux distributions will no longer need a C compiler to install ujson (no issue to link).

Changes proposed in this pull request:

* Build wheels of musl Linux using the PEP656 implementation released yesterday. Its design mirrors that of its glibc counterpart, the manylinux series, making this PR easy.

I've done a few PyPI stats queries. In the last month, these are how many downloads ujson had from musl Linux users for each architecture. I don't know if you consider 144 downloads enough to warrant adding `musllinux_1_1_aarch64` too?

Row | cpu | counts |  
-- | -- | -- | --
1 | ppc64le | 4 |  
2 | armv7l | 27 |  
3 | i686 | 6 |  
4 | x86_64 | 35266 |  
5 | aarch64 | 144 |  
