### PR TITLE
Use declarative setup metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.1
+    rev: v2.26.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.9b0
     hooks:
       - id: black
         args: ["--target-version", "py36"]
@@ -38,6 +38,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: "^.github/.*_TEMPLATE.md"
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.17.0
+    hooks:
+      - id: setup-cfg-fmt
+        args: ["--max-py-version=3.10"]
 
 ci:
   autoupdate_schedule: quarterly

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,32 @@
+[metadata]
+name = ujson
+description = Ultra fast JSON encoder and decoder for Python
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+url = https://github.com/ultrajson/ultrajson
+author = Jonas Tarnstrom
+license_file = LICENSE.txt
+platforms = any
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Programming Language :: C
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+download_url = https://github.com/ultrajson/ultrajson
+project_urls =
+    Source=https://github.com/ultrajson/ultrajson
+
+[options]
+python_requires = >=3.6
+setup_requires =
+    setuptools_scm
+
 [flake8]
 max_line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,6 @@ from glob import glob
 
 from setuptools import Extension, setup
 
-CLASSIFIERS = """
-Development Status :: 5 - Production/Stable
-Intended Audience :: Developers
-License :: OSI Approved :: BSD License
-Programming Language :: C
-Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: 3 :: Only
-"""
-
 dconv_source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 dconv_source_files.append("./lib/dconv_wrapper.cc")
 
@@ -34,11 +20,6 @@ module1 = Extension(
     extra_link_args=["-lstdc++", "-lm"],
 )
 
-
-with open("README.rst", encoding="utf-8") as f:
-    long_description = f.read()
-
-
 with open("python/version_template.h") as f:
     version_template = f.read()
 
@@ -50,21 +31,10 @@ def local_scheme(version):
 
 
 setup(
-    name="ujson",
-    description="Ultra fast JSON encoder and decoder for Python",
-    long_description=long_description,
     ext_modules=[module1],
-    author="Jonas Tarnstrom",
-    download_url="https://github.com/ultrajson/ultrajson",
-    platforms=["any"],
-    url="https://github.com/ultrajson/ultrajson",
-    project_urls={"Source": "https://github.com/ultrajson/ultrajson"},
     use_scm_version={
         "local_scheme": local_scheme,
         "write_to": "python/version.h",
         "write_to_template": version_template,
     },
-    setup_requires=["setuptools_scm"],
-    python_requires=">=3.6",
-    classifiers=[x for x in CLASSIFIERS.split("\n") if x],
 )


### PR DESCRIPTION
Changes proposed in this pull request:

* Move static stuff to `setup.cfg` using https://github.com/asottile/setup-py-upgrade
* Use https://github.com/asottile/setup-cfg-fmt for a consistent `setup.cfg` format
