### PR TITLE
Build wheels for musl aarch64 (aka ARM) Linux (musllinux_1_1_aarch64)

### DIFF
--- a/.github/workflows/deploy-wheels-linux.yml
+++ b/.github/workflows/deploy-wheels-linux.yml
@@ -18,6 +18,7 @@ jobs:
             "manylinux2014_aarch64",
             "manylinux2014_i686",
             "manylinux2014_x86_64",
+            "musllinux_1_1_aarch64",
             "musllinux_1_1_x86_64",
         ]
         python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
@@ -31,6 +32,7 @@ jobs:
           - { python-version: "3.10-dev", version-tag: "cp310-cp310" }
         exclude:
           # No PyPy3 on musllinux
+          - { python-version: "pypy3", wheel: "musllinux_1_1_aarch64" }
           - { python-version: "pypy3", wheel: "musllinux_1_1_x86_64" }
 
     steps:

--- a/.github/workflows/deploy-wheels-linux.yml
+++ b/.github/workflows/deploy-wheels-linux.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - ".github/workflows/deploy-wheels-linux.yml"
+      - "scripts/build-manylinux-wheels.sh"
   release:
     types:
       - published
@@ -75,7 +79,9 @@ jobs:
       run: twine upload --skip-existing dist/*.whl
 
     - name: Publish package to TestPyPI
-      if: github.repository == 'ultrajson/ultrajson'
+      if: |
+        github.repository == 'ultrajson/ultrajson' &&
+        github.ref == 'refs/heads/main'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
Addresses [#476 (comment)](https://github.com/ultrajson/ultrajson/pull/476#issuecomment-922728866).

Changes proposed in this pull request:

* Add musl aarch64 wheels to the build matrix.