### PR TITLE
Test and deploy on Python 3.10 final

### DIFF
--- a/.github/workflows/deploy-wheels-linux.yml
+++ b/.github/workflows/deploy-wheels-linux.yml
@@ -25,7 +25,7 @@ jobs:
             "musllinux_1_1_aarch64",
             "musllinux_1_1_x86_64",
         ]
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
           # Add version-tag variable to existing jobs
           - { python-version: "pypy3", version-tag: "pp37-pypy37_pp73" }
@@ -33,7 +33,7 @@ jobs:
           - { python-version: "3.7", version-tag: "cp37-cp37m" }
           - { python-version: "3.8", version-tag: "cp38-cp38" }
           - { python-version: "3.9", version-tag: "cp39-cp39" }
-          - { python-version: "3.10-dev", version-tag: "cp310-cp310" }
+          - { python-version: "3.10", version-tag: "cp310-cp310" }
         exclude:
           # No PyPy3 on musllinux
           - { python-version: "pypy3", wheel: "musllinux_1_1_aarch64" }

--- a/.github/workflows/deploy-wheels-windows-macos.yml
+++ b/.github/workflows/deploy-wheels-windows-macos.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         architecture: [x64, x86]
         exclude:
           - {os: macos-latest, architecture: x86}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
         exclude:
           - { python-version: "pypy3", os: macos-latest }


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

We're still waiting for Travis CI to add `3.10`, although we could already test on `3.10-dev`:

* https://travis-ci.community/t/add-python-3-10/12220?u=hugovk
