### PR TITLE
Drop support for soon-EOL Python 3.6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,27 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
-        os: [ubuntu-18.04]
+        python-version: ["3.10"]
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Ubuntu cache
-        uses: actions/cache@v2
-        if: startsWith(matrix.os, 'ubuntu')
-        with:
-          path: ~/.cache/pip
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   build-native-wheels:
@@ -143,19 +144,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U build twine wheel
 
       - name: Build package
         run: |
           git tag
           python setup.py --version
-          python setup.py sdist --format=gztar
-          twine check dist/*
+          python -m build --sdist
+          twine check --strict dist/*
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,12 +1,15 @@
 name: Sync labels
+
 on:
   push:
     branches:
       - main
     paths:
       - .github/labels.yml
+  workflow_dispatch:
+
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,10 +5,11 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
-    if: github.repository == 'ultrajson/ultrajson'
+    if: github.repository_owner == 'ultrajson'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "main"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,20 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
         exclude:
-          - { python-version: "pypy3", os: macos-latest }
+          - { python-version: "pypy-3.8", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v2
@@ -20,21 +23,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v2-${{
-            hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v2-
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -40,10 +40,9 @@ repos:
         exclude: "^.github/.*_TEMPLATE.md"
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
-        args: ["--max-py-version=3.10"]
 
 ci:
   autoupdate_schedule: quarterly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ arch:
 
 # Only test oldest and newest supported versions
 python:
-  - "3.6"
-  - "3.9"
+  - "3.7"
+  - "3.10-dev"
 
 jobs:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
 UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for
-Python 3.6+.
+Python 3.7+.
 
 Install with pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
 [tool.black]
-target_version = ["py36"]
+target_version = ["py37"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Programming Language :: C
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -24,9 +23,9 @@ project_urls =
     Source=https://github.com/ultrajson/ultrajson
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
-    setuptools_scm
+    setuptools-scm
 
 [flake8]
 max_line_length = 88


### PR DESCRIPTION
Changes proposed in this pull request:

* Drop support for Python 3.6, it's soon EOL
* Replace [deprecated `pypyX`](https://github.com/actions/setup-python/issues/244#issuecomment-925966022) (which is also Python 3.6) with [explicit `pypy-X.Y`](https://github.com/actions/setup-python#specifying-a-pypy-version)
* Let's also make wheels for both PyPy3.7 and PyPy3.8
* Bump benchmarking from Ubuntu 18.04/Python 3.8 to Ubuntu 20.04/Python 3.10
* Cache pip using https://github.com/actions/setup-python instead of https://github.com/actions/cache
* Remove one instance of calling `setup.py` (calling it is deprecated) with https://github.com/pypa/build
* Delete unused `scripts/build-manylinux.py`


| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| _3.6_   | 3.6.15 | 2016-12-23 | _2021-12-23_ |

Here's the pip installs for ujson from PyPI for October 2021:

| category | percent |  downloads |
|:---------|--------:|-----------:|
| 3.7      |  78.51% | 15,547,674 |
| 3.9      |   6.54% |  1,294,795 |
| 3.8      |   6.12% |  1,210,988 |
| null     |   3.66% |    724,945 |
| _3.6_      |   _3.66%_ |    724,471 |
| 2.7      |   1.26% |    248,535 |
| 3.5      |   0.16% |     32,165 |
| 3.10     |   0.10% |     19,036 |
| 3.4      |   0.00% |        248 |
| 3.11     |   0.00% |         26 |
| 3.3      |   0.00% |         18 |
| Total    |         | 19,802,901 |

Date range: 2021-10-01 - 2021-10-31

Source: `pip install -U pypistats && pypistats python_minor ujson --last-month`


# TODO

* [x] Merge https://github.com/ultrajson/ultrajson/pull/491 first.
* [x] When ready to merge, adjust the required CI status checks.