### PR TITLE
Install Twine to upload to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - uses: actions/setup-python@v2
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          cache: pip
+          cache-dependency-path: ".github/workflows/deploy.yml"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install cibuildwheel==2.3.0
+          python -m pip install -U twine
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
@@ -83,10 +90,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      - uses: actions/setup-python@v2
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          cache: pip
+          cache-dependency-path: ".github/workflows/deploy.yml"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install cibuildwheel==2.3.0
+          python -m pip install -U twine
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU


### PR DESCRIPTION
Follow on from https://github.com/ultrajson/ultrajson/pull/491, to fix https://github.com/ultrajson/ultrajson/actions/runs/1578092423.

Changes proposed in this pull request:

* Install Twine to upload to PyPI
* Also cache pip

