### PR TITLE
Strip debugging symbols from Linux binaries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from glob import glob
 import platform
+from glob import glob
 
 from setuptools import Extension, setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 from glob import glob
+import platform
 
 from setuptools import Extension, setup
 
 dconv_source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 dconv_source_files.append("./lib/dconv_wrapper.cc")
+
+strip_flags = ["-Wl,--strip-all"] if platform.system() == "Linux" else []
 
 module1 = Extension(
     "ujson",
@@ -17,7 +20,7 @@ module1 = Extension(
     ],
     include_dirs=["./python", "./lib", "./deps/double-conversion/double-conversion"],
     extra_compile_args=["-D_GNU_SOURCE"],
-    extra_link_args=["-lstdc++", "-lm"],
+    extra_link_args=["-lstdc++", "-lm"] + strip_flags,
 )
 
 with open("python/version_template.h") as f:


### PR DESCRIPTION
Fixes nothing.

Changes proposed in this pull request:

Apply [strip](https://www.man7.org/linux/man-pages/man1/strip.1.html) to remove all debugging only symbols from binaries. Doing so reduces the size of the package (around 250KB reduces to 50KB on Linux) at the expense of being less friendly to debug using gdb (GNU's debugger) (ever use C debuggers when using ujson?).
