### PR TITLE
Travis CI: Test on Python 3.10 release rather than alpha version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ arch:
 # Only test oldest and newest supported versions
 python:
   - "3.7"
-  - "3.10-dev"
+  - "3.10"
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ arch:
   - arm64
   - s390x
 
+dist: focal
+
 # Only test oldest and newest supported versions
 python:
   - "3.7"


### PR DESCRIPTION
E.g. https://app.travis-ci.com/github/ultrajson/ultrajson/jobs/558497582 just now ran Python 3.10.0a5+.