### PR TITLE
Verify that JSONDecodeError is an actual subclass of ValueError, not just an alias

### DIFF
--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -616,6 +616,7 @@ def test_decode_raises_for_long_input(test_input, expected):
 
 def test_decode_exception_is_value_error():
     assert issubclass(ujson.JSONDecodeError, ValueError)
+    assert ujson.JSONDecodeError is not ValueError
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up for #498. Sorry, I forgot that `issubclass(x, x)` is `True`, therefore that test would pass even if `JSONDecodeError` were simply an alias of `ValueError` rather than a proper subclass. This adds a check that they are not identical.