### PR TITLE
Fix exceptions on encoding list or dict elements and non-overflow errors on int handling getting silenced

### DIFF
--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -659,8 +659,10 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       /*
       There should already be an exception at the Python level.
       This however sets the errorMsg so recursion on arrays and objects stops.
+      endTypeContext must not be called here as beginTypeContext already cleans up in the INVALID case.
       */
       SetError (obj, enc, "Invalid type");
+      enc->level--;
       return;
     }
 
@@ -688,6 +690,9 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
         encode (iterObj, enc, NULL, 0);
         if (enc->errorMsg)
         {
+          enc->iterEnd(obj, &tc);
+          enc->endTypeContext(obj, &tc);
+          enc->level--;
           return;
         }
         count ++;
@@ -736,6 +741,9 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
         encode (iterObj, enc, objName, szlen);
         if (enc->errorMsg)
         {
+          enc->iterEnd(obj, &tc);
+          enc->endTypeContext(obj, &tc);
+          enc->level--;
           return;
         }
         count ++;

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -656,6 +656,11 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
   {
     case JT_INVALID:
     {
+      /*
+      There should already be an exception at the Python level.
+      This however sets the errorMsg so recursion on arrays and objects stops.
+      */
+      SetError (obj, enc, "Invalid type");
       return;
     }
 
@@ -681,6 +686,10 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
         enc->level ++;
         Buffer_AppendIndentUnchecked (enc, enc->level);
         encode (iterObj, enc, NULL, 0);
+        if (enc->errorMsg)
+        {
+          return;
+        }
         count ++;
       }
 
@@ -725,6 +734,10 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
         enc->level ++;
         Buffer_AppendIndentUnchecked (enc, enc->level);
         encode (iterObj, enc, objName, szlen);
+        if (enc->errorMsg)
+        {
+          return;
+        }
         count ++;
       }
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -505,11 +505,17 @@ BEGIN:
       GET_TC(tc)->unsignedLongValue = PyLong_AsUnsignedLongLong(obj);
 
       exc = PyErr_Occurred();
-      if (exc && PyErr_ExceptionMatches(PyExc_OverflowError))
+      if (exc)
       {
         PRINTMARK();
         goto INVALID;
       }
+    }
+    else
+    if (exc)
+    {
+      PRINTMARK();
+      goto INVALID;
     }
 
     return;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -659,6 +659,10 @@ def test_dumps_raises(test_input, expected_exception, expected_message):
         (float("inf"), OverflowError),
         (-float("inf"), OverflowError),
         (12839128391289382193812939, OverflowError),
+        ([12839128391289382193812939], OverflowError),
+        ([12839128391289382193812939, 42], OverflowError),
+        ({"a": 12839128391289382193812939}, OverflowError),
+        ({"a": 12839128391289382193812939, "b": 42}, OverflowError),
     ],
 )
 def test_encode_raises_allow_nan(test_input, expected_exception):


### PR DESCRIPTION
Fixes #273

I have no idea how to make `PyLong_As*` raise an exception other than `OverflowError` for testing that part, but it should be possible in theory (e.g. running out of memory at that exact moment, I guess?).