### PR TITLE
Add env var to control stripping debug info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,10 @@ from setuptools import Extension, setup
 dconv_source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 dconv_source_files.append("./lib/dconv_wrapper.cc")
 
-if platform.system() == "Linux" and environ.get(
-    "UJSON_BUILD_NO_STRIP", "0"
-) not in ("1", "True"):
+if platform.system() == "Linux" and environ.get("UJSON_BUILD_NO_STRIP", "0") not in (
+    "1",
+    "True",
+):
     strip_flags = ["-Wl,--strip-all"]
 else:
     strip_flags = []

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
 import platform
 from glob import glob
+from os import environ
 
 from setuptools import Extension, setup
 
 dconv_source_files = glob("./deps/double-conversion/double-conversion/*.cc")
 dconv_source_files.append("./lib/dconv_wrapper.cc")
 
-strip_flags = ["-Wl,--strip-all"] if platform.system() == "Linux" else []
+if platform.system() == "Linux" and environ.get(
+    "UJSON_BUILD_NO_STRIP", "0"
+) not in ("1", "True"):
+    strip_flags = ["-Wl,--strip-all"]
+else:
+    strip_flags = []
 
 module1 = Extension(
     "ujson",


### PR DESCRIPTION
Before this commit, debug info is stripped unconditionally on Linux.

This commit adds an environment variable `UJSON_BUILD_NO_STRIP` that disables this behavior. This is helpful for distribution packagers who would otherwise have to patch `setup.py` to prevent stripping.

Fixes #506

Changes proposed in this pull request:

*  When environment variable `UJSON_BUILD_NO_STRIP` is set to `1` or `True`, do not strip debug symbols from the compiled extension. When it is unset, or set to any other value, maintain the previous behavior of stripping them if the platform is Linux.