### PR TITLE
Support dynamically linking against system double-conversion library

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,39 @@ Linux 5.0.0-1032-azure x86_64 #34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020
 | Complex object                                                                |            |            |            |            |            |
 | encode                                                                        |        533 |        582 |            |        408 |        431 |
 | decode                                                                        |        466 |        454 |            |        154 |        164 |
+
+## Build options
+
+For those with particular needs, such as Linux distribution packagers, several
+build options are provided in the form of environment variables.
+
+### Debugging symbols
+
+#### UJSON_BUILD_NO_STRIP
+
+By default, debugging symbols are stripped on Linux platforms. Setting this
+environment variable with a value of `1` or `True` disables this behavior.
+
+### Using an external or system copy of the double-conversion library
+
+These two environment variables are typically used together, something like:
+
+```sh
+export UJSON_BUILD_DC_INCLUDES='/usr/include/double-conversion'
+export UJSON_BUILD_DC_LIBS='-ldouble-conversion'
+```
+
+Users planning to link against an external shared library should be aware of
+the ABI-compatibility requirements this introduces when upgrading system
+libraries or copying compiled wheels to other machines.
+
+#### UJSON_BUILD_DC_INCLUDES
+
+One or more directories, delimited by `os.pathsep` (same as the `PATH`
+environment variable), in which to look for `double-conversion` header files;
+the default is to use the bundled copy.
+
+#### UJSON_BUILD_DC_LIBS
+
+Compiler flags needed to link the `double-conversion` library; the default
+is to use the bundled copy.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import platform
 from glob import glob
-from os import environ
+from os import environ, pathsep
+import shlex
 
 from setuptools import Extension, setup
 
@@ -29,10 +30,10 @@ module1 = Extension(
     + environ.get(
         "UJSON_BUILD_DC_INCLUDES",
         "./deps/double-conversion/double-conversion",
-    ).split(),
+    ).split(pathsep),
     extra_compile_args=["-D_GNU_SOURCE"],
     extra_link_args=["-lstdc++", "-lm"]
-    + environ.get("UJSON_BUILD_DC_LIBS", "").split()
+    + shlex.split(environ.get("UJSON_BUILD_DC_LIBS", ""))
     + strip_flags,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,16 @@ import shlex
 
 from setuptools import Extension, setup
 
-dconv_source_files = glob("./deps/double-conversion/double-conversion/*.cc")
+dconv_includes = environ.get(
+    "UJSON_BUILD_DC_INCLUDES",
+    "./deps/double-conversion/double-conversion",
+).split(pathsep)
+dconv_libs = shlex.split(environ.get("UJSON_BUILD_DC_LIBS", ""))
+dconv_source_files = []
+if not dconv_libs:
+    dconv_source_files.extend(
+        glob("./deps/double-conversion/double-conversion/*.cc")
+    )
 dconv_source_files.append("./lib/dconv_wrapper.cc")
 
 if platform.system() == "Linux" and environ.get("UJSON_BUILD_NO_STRIP", "0") not in (
@@ -26,15 +35,9 @@ module1 = Extension(
         "./lib/ultrajsonenc.c",
         "./lib/ultrajsondec.c",
     ],
-    include_dirs=["./python", "./lib"]
-    + environ.get(
-        "UJSON_BUILD_DC_INCLUDES",
-        "./deps/double-conversion/double-conversion",
-    ).split(pathsep),
+    include_dirs=["./python", "./lib"] + dconv_includes,
     extra_compile_args=["-D_GNU_SOURCE"],
-    extra_link_args=["-lstdc++", "-lm"]
-    + shlex.split(environ.get("UJSON_BUILD_DC_LIBS", ""))
-    + strip_flags,
+    extra_link_args=["-lstdc++", "-lm"] + dconv_libs + strip_flags,
 )
 
 with open("python/version_template.h") as f:

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,15 @@ module1 = Extension(
         "./lib/ultrajsonenc.c",
         "./lib/ultrajsondec.c",
     ],
-    include_dirs=["./python", "./lib", "./deps/double-conversion/double-conversion"],
+    include_dirs=["./python", "./lib"]
+    + environ.get(
+        "UJSON_BUILD_DC_INCLUDES",
+        "./deps/double-conversion/double-conversion",
+    ).split(),
     extra_compile_args=["-D_GNU_SOURCE"],
-    extra_link_args=["-lstdc++", "-lm"] + strip_flags,
+    extra_link_args=["-lstdc++", "-lm"]
+    + environ.get("UJSON_BUILD_DC_LIBS", "").split()
+    + strip_flags,
 )
 
 with open("python/version_template.h") as f:

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,14 @@ from os import environ, pathsep
 
 from setuptools import Extension, setup
 
-dconv_includes = environ.get(
-    "UJSON_BUILD_DC_INCLUDES",
-    "./deps/double-conversion/double-conversion",
-).split(pathsep)
+dconv_includes = [
+    dir
+    for dir in environ.get(
+        "UJSON_BUILD_DC_INCLUDES",
+        "./deps/double-conversion/double-conversion",
+    ).split(pathsep)
+    if dir
+]
 dconv_libs = shlex.split(environ.get("UJSON_BUILD_DC_LIBS", ""))
 dconv_source_files = []
 if not dconv_libs:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import platform
+import shlex
 from glob import glob
 from os import environ, pathsep
-import shlex
 
 from setuptools import Extension, setup
 
@@ -12,9 +12,7 @@ dconv_includes = environ.get(
 dconv_libs = shlex.split(environ.get("UJSON_BUILD_DC_LIBS", ""))
 dconv_source_files = []
 if not dconv_libs:
-    dconv_source_files.extend(
-        glob("./deps/double-conversion/double-conversion/*.cc")
-    )
+    dconv_source_files.extend(glob("./deps/double-conversion/double-conversion/*.cc"))
 dconv_source_files.append("./lib/dconv_wrapper.cc")
 
 if platform.system() == "Linux" and environ.get("UJSON_BUILD_NO_STRIP", "0") not in (


### PR DESCRIPTION
New environment variables `UJSON_BUILD_DC_INCLUDES` and `UJSON_BUILD_DC_LIBS` allow overriding the include path for double-conversion and adding linker flags for an external double-conversion library. They should generally be used together.

This is particularly useful to Linux distribution packagers who would otherwise need a patch to unbundle `double-conversion`. (It may still be necessary to `rm -rf deps/double-conversion`; I have not checked, as Fedora Linux would require this anyway.)

Fixes #375

Changes proposed in this pull request:

* Allow overriding default include path/paths for `double-conversion` with environment variable `UJSON_BUILD_DC_INCLUDES`. This allows multiple whitespace-delimited paths but as a consequence doesn’t support paths containing whitespace, which is probably acceptable for the intended uses. For example, Linux distributions building against a system copy of `double-conversion` will want something like `UJSON_BUILD_DC_INCLUDES=/usr/include/double-conversion`.
* Allow adding linker flags for `double-conversion` with environment variable `UJSON_BUILD_DC_LIBS`; by default there are still none. For example, Linux distributions building against a system copy of `double-conversion` will want something like `UJSON_BUILD_DC_LIBS=-ldouble-conversion`.