### PR TITLE
Remove dead code that used to handle the separate int type in Python 2

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -198,7 +198,6 @@ typedef struct __JSONObjectEncoder
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
   JSINT64 (*getLongValue)(JSOBJ obj, JSONTypeContext *tc);
   JSUINT64 (*getUnsignedLongValue)(JSOBJ obj, JSONTypeContext *tc);
-  JSINT32 (*getIntValue)(JSOBJ obj, JSONTypeContext *tc);
   double (*getDoubleValue)(JSOBJ obj, JSONTypeContext *tc);
 
   /*

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -518,22 +518,6 @@ static void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value)
         Buffer_AppendCharUnchecked(enc, ' ');
 }
 
-static void Buffer_AppendIntUnchecked(JSONObjectEncoder *enc, JSINT32 value)
-{
-  char* wstr;
-  JSUINT32 uvalue = (value < 0) ? -value : value;
-
-  wstr = enc->offset;
-  // Conversion. Number is reversed.
-
-  do *wstr++ = (char)(48 + (uvalue % 10)); while(uvalue /= 10);
-  if (value < 0) *wstr++ = '-';
-
-  // Reverse string
-  strreverse(enc->offset,wstr - 1);
-  enc->offset += (wstr - (enc->offset));
-}
-
 static void Buffer_AppendLongUnchecked(JSONObjectEncoder *enc, JSINT64 value)
 {
   char* wstr;
@@ -768,12 +752,6 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
     case JT_ULONG:
     {
       Buffer_AppendUnsignedLongUnchecked (enc, enc->getUnsignedLongValue(obj, &tc));
-      break;
-    }
-
-    case JT_INT:
-    {
-      Buffer_AppendIntUnchecked (enc, enc->getIntValue(obj, &tc));
       break;
     }
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -88,22 +88,6 @@ struct PyDictIterState
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)
 #define PRINTMARK()
 
-#ifdef _LP64
-static void *PyIntToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
-{
-  PyObject *obj = (PyObject *) _obj;
-  *((JSINT64 *) outValue) = PyLong_AsLong (obj);
-  return NULL;
-}
-#else
-static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
-{
-  PyObject *obj = (PyObject *) _obj;
-  *((JSINT32 *) outValue) = PyLong_AsLong (obj);
-  return NULL;
-}
-#endif
-
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   *((JSINT64 *) outValue) = GET_TC(tc)->longValue;
@@ -521,17 +505,6 @@ BEGIN:
     return;
   }
   else
-  if (PyLong_Check(obj))
-  {
-    PRINTMARK();
-#ifdef _LP64
-    pc->PyTypeToJSON = PyIntToINT64; tc->type = JT_LONG;
-#else
-    pc->PyTypeToJSON = PyIntToINT32; tc->type = JT_INT;
-#endif
-    return;
-  }
-  else
   if (UNLIKELY(PyBytes_Check(obj)))
   {
     PRINTMARK();
@@ -741,14 +714,6 @@ static JSUINT64 Object_getUnsignedLongValue(JSOBJ obj, JSONTypeContext *tc)
   return ret;
 }
 
-static JSINT32 Object_getIntValue(JSOBJ obj, JSONTypeContext *tc)
-{
-  JSINT32 ret;
-  obj = GET_OBJ(obj, tc);
-  GET_TC(tc)->PyTypeToJSON (obj, tc, &ret, NULL);
-  return ret;
-}
-
 static double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc)
 {
   double ret;
@@ -810,7 +775,6 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_getStringValue,
     Object_getLongValue,
     Object_getUnsignedLongValue,
-    Object_getIntValue,
     Object_getDoubleValue,
     Object_iterNext,
     Object_iterEnd,


### PR DESCRIPTION
Python 3 does not have the `PyInt` vs `PyLong` distinction that Python 2 had. Commit ff8e64ca made that replacement, but obviously the second `if (PyLong_Check(obj))` branch can never be executed, thus all the code exclusively referenced by it is also dead.