### PR TITLE
Support parsing NaN, Infinity and -Infinity

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -166,6 +166,7 @@ enum JSTYPES
   JT_ARRAY,     // Array structure
   JT_OBJECT,    // Key/Value structure
   JT_INVALID,   // Internal, do not return nor expect
+  JT_NAN,       // Not A Number
   JT_POS_INF,   // Positive infinity
   JT_NEG_INF,   // Negative infinity
 };
@@ -323,6 +324,7 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newTrue)(void *prv);
   JSOBJ (*newFalse)(void *prv);
   JSOBJ (*newNull)(void *prv);
+  JSOBJ (*newNaN)(void *prv);
   JSOBJ (*newPosInf)(void *prv);
   JSOBJ (*newNegInf)(void *prv);
   JSOBJ (*newObject)(void *prv);

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -166,6 +166,8 @@ enum JSTYPES
   JT_ARRAY,     // Array structure
   JT_OBJECT,    // Key/Value structure
   JT_INVALID,   // Internal, do not return nor expect
+  JT_POS_INF,   // Positive infinity
+  JT_NEG_INF,   // Negative infinity
 };
 
 typedef void * JSOBJ;
@@ -321,6 +323,8 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newTrue)(void *prv);
   JSOBJ (*newFalse)(void *prv);
   JSOBJ (*newNull)(void *prv);
+  JSOBJ (*newPosInf)(void *prv);
+  JSOBJ (*newNegInf)(void *prv);
   JSOBJ (*newObject)(void *prv);
   JSOBJ (*newArray)(void *prv);
   JSOBJ (*newInt)(void *prv, JSINT32 value);

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -98,10 +98,16 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds
 
   JSUINT64 overflowLimit = LLONG_MAX;
 
-  if (*(offset) == '-')
-  {
-    offset ++;
-    intNeg = -1;
+  if (*(offset) == 'I') {
+      goto DECODE_INF;
+  } else if (*(offset) == 'N') {
+      goto DECODE_NAN;
+  } else if (*(offset) == '-') {
+      offset++;
+      intNeg = -1;
+      if (*(offset) == 'I') {
+          goto DECODE_INF;
+      }
     overflowLimit = LLONG_MIN;
   }
 
@@ -189,6 +195,48 @@ BREAK_INT_LOOP:
   {
     return ds->dec->newInt(ds->prv, (JSINT32) (intValue * intNeg));
   }
+
+DECODE_NAN:
+    offset++;
+    if (*(offset++) != 'a') goto SET_NAN_ERROR;
+    if (*(offset++) != 'N') goto SET_NAN_ERROR;
+
+    ds->lastType = JT_NULL;
+    ds->start = offset;
+    return ds->dec->newNull(ds->prv);
+
+SET_NAN_ERROR:
+    return SetError(ds, -1, "Unexpected character found when decoding 'NaN'");
+
+DECODE_INF:
+    offset++;
+    if (*(offset++) != 'n') goto SET_INF_ERROR;
+    if (*(offset++) != 'f') goto SET_INF_ERROR;
+    if (*(offset++) != 'i') goto SET_INF_ERROR;
+    if (*(offset++) != 'n') goto SET_INF_ERROR;
+    if (*(offset++) != 'i') goto SET_INF_ERROR;
+    if (*(offset++) != 't') goto SET_INF_ERROR;
+    if (*(offset++) != 'y') goto SET_INF_ERROR;
+
+    ds->start = offset;
+
+    if (intNeg == 1) {
+      ds->lastType = JT_POS_INF;
+      return ds->dec->newPosInf(ds->prv);
+    } else {
+      ds->lastType = JT_NEG_INF;
+      return ds->dec->newNegInf(ds->prv);
+    }
+
+SET_INF_ERROR:
+    if (intNeg == 1) {
+      const char *msg = "Unexpected character found when decoding 'Infinity'";
+      return SetError(ds, -1, msg);
+    } else {
+      const char *msg = "Unexpected character found when decoding '-Infinity'";
+      return SetError(ds, -1, msg);
+    }
+
 }
 
 static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_true ( struct DecoderState *ds)
@@ -732,6 +780,8 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds)
       case '7':
       case '8':
       case '9':
+      case 'I':
+      case 'N':
       case '-':
         return decode_numeric (ds);
 

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -201,9 +201,9 @@ DECODE_NAN:
     if (*(offset++) != 'a') goto SET_NAN_ERROR;
     if (*(offset++) != 'N') goto SET_NAN_ERROR;
 
-    ds->lastType = JT_NULL;
+    ds->lastType = JT_NAN;
     ds->start = offset;
-    return ds->dec->newNull(ds->prv);
+    return ds->dec->newNaN(ds->prv);
 
 SET_NAN_ERROR:
     return SetError(ds, -1, "Unexpected character found when decoding 'NaN'");

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -79,12 +79,17 @@ static JSOBJ Object_newNull(void *prv)
   Py_RETURN_NONE;
 }
 
-JSOBJ Object_newPosInf(void *prv)
+static JSOBJ Object_newNaN(void *prv)
+{
+    return PyFloat_FromDouble(Py_NAN);
+}
+
+static JSOBJ Object_newPosInf(void *prv)
 {
     return PyFloat_FromDouble(Py_HUGE_VAL);
 }
 
-JSOBJ Object_newNegInf(void *prv)
+static JSOBJ Object_newNegInf(void *prv)
 {
     return PyFloat_FromDouble(-Py_HUGE_VAL);
 }
@@ -139,6 +144,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newTrue,
     Object_newFalse,
     Object_newNull,
+    Object_newNaN,
     Object_newPosInf,
     Object_newNegInf,
     Object_newObject,

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -79,6 +79,16 @@ static JSOBJ Object_newNull(void *prv)
   Py_RETURN_NONE;
 }
 
+JSOBJ Object_newPosInf(void *prv)
+{
+    return PyFloat_FromDouble(Py_HUGE_VAL);
+}
+
+JSOBJ Object_newNegInf(void *prv)
+{
+    return PyFloat_FromDouble(-Py_HUGE_VAL);
+}
+
 static JSOBJ Object_newObject(void *prv)
 {
   return PyDict_New();
@@ -129,6 +139,8 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newTrue,
     Object_newFalse,
     Object_newNull,
+    Object_newPosInf,
+    Object_newNegInf,
     Object_newObject,
     Object_newArray,
     Object_newInteger,

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -672,10 +672,18 @@ def test_encode_raises_allow_nan(test_input, expected_exception):
 
 def test_nan_inf_support():
     import math
+
     text = '["a", NaN, "NaN", Infinity, "Infinity", -Infinity, "-Infinity"]'
     data = ujson.loads(text)
-    expected = ["a", float('nan'), "NaN", float('inf'), "Infinity",
-                -float('inf'), "-Infinity"]
+    expected = [
+        "a",
+        float("nan"),
+        "NaN",
+        float("inf"),
+        "Infinity",
+        -float("inf"),
+        "-Infinity",
+    ]
     for a, b in zip(data, expected):
         assert a == b or math.isnan(a) and math.isnan(b)
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -670,6 +670,14 @@ def test_encode_raises_allow_nan(test_input, expected_exception):
         ujson.dumps(test_input, allow_nan=False)
 
 
+def test_nan_inf_support():
+    text = '["a", NaN, "NaN", Infinity, "Infinity", -Infinity, "-Infinity"]'
+    data = ujson.loads(text)
+    expected = ["a", float('nan'), "NaN", float('inf'), "Infinity", -float('inf'), "-Infinity"]
+    for a, b in zip(data, expected):
+        assert a == b or a is b
+
+
 @pytest.mark.parametrize(
     "test_input",
     [

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -671,11 +671,13 @@ def test_encode_raises_allow_nan(test_input, expected_exception):
 
 
 def test_nan_inf_support():
+    import math
     text = '["a", NaN, "NaN", Infinity, "Infinity", -Infinity, "-Infinity"]'
     data = ujson.loads(text)
-    expected = ["a", float('nan'), "NaN", float('inf'), "Infinity", -float('inf'), "-Infinity"]
+    expected = ["a", float('nan'), "NaN", float('inf'), "Infinity",
+                -float('inf'), "-Infinity"]
     for a, b in zip(data, expected):
-        assert a == b or a is b
+        assert a == b or math.isnan(a) and math.isnan(b)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -699,47 +699,47 @@ def test_special_singletons():
 
 
 @pytest.mark.parametrize(
-    "test_input, expected_exception, expected_message",
+    "test_input, expected_message",
     [
-        ("n", ujson.JSONDecodeError, "Unexpected character .* 'null'"),
-        ("N", ujson.JSONDecodeError, "Unexpected character .*'NaN'"),
-        ("NA", ujson.JSONDecodeError, "Unexpected character .* 'NaN'"),
-        ("Na N", ujson.JSONDecodeError, "Unexpected character .* 'NaN'"),
-        ("nan", ujson.JSONDecodeError, "Unexpected character .* 'null'"),
-        ("none", ujson.JSONDecodeError, "Unexpected character .* 'null'"),
-        ("i", ujson.JSONDecodeError, "Expected object or value"),
-        ("I", ujson.JSONDecodeError, "Unexpected character .* 'Infinity'"),
-        ("Inf", ujson.JSONDecodeError, "Unexpected character .* 'Infinity'"),
-        ("InfinitY", ujson.JSONDecodeError, "Unexpected character .* 'Infinity'"),
-        ("-i", ujson.JSONDecodeError, "Trailing data"),
-        ("-I", ujson.JSONDecodeError, "Unexpected character .* '-Infinity'"),
-        ("-Inf", ujson.JSONDecodeError, "Unexpected character .* '-Infinity'"),
-        ("-InfinitY", ujson.JSONDecodeError, "Unexpected character .* '-Infinity'"),
-        ("- i", ujson.JSONDecodeError, "Trailing data"),
-        ("- I", ujson.JSONDecodeError, "Trailing data"),
-        ("- Inf", ujson.JSONDecodeError, "Trailing data"),
-        ("- InfinitY", ujson.JSONDecodeError, "Trailing data"),
+        ("n", "Unexpected character .* 'null'"),
+        ("N", "Unexpected character .*'NaN'"),
+        ("NA", "Unexpected character .* 'NaN'"),
+        ("Na N", "Unexpected character .* 'NaN'"),
+        ("nan", "Unexpected character .* 'null'"),
+        ("none", "Unexpected character .* 'null'"),
+        ("i", "Expected object or value"),
+        ("I", "Unexpected character .* 'Infinity'"),
+        ("Inf", "Unexpected character .* 'Infinity'"),
+        ("InfinitY", "Unexpected character .* 'Infinity'"),
+        ("-i", "Trailing data"),
+        ("-I", "Unexpected character .* '-Infinity'"),
+        ("-Inf", "Unexpected character .* '-Infinity'"),
+        ("-InfinitY", "Unexpected character .* '-Infinity'"),
+        ("- i", "Trailing data"),
+        ("- I", "Trailing data"),
+        ("- Inf", "Trailing data"),
+        ("- InfinitY", "Trailing data"),
     ],
 )
-def test_incomplete_special_inputs(test_input, expected_exception, expected_message):
-    with pytest.raises(expected_exception, match=expected_message):
-        print(f"test_input = {test_input!r}")
+def test_incomplete_special_inputs(test_input, expected_message):
+    with pytest.raises(ujson.JSONDecodeError, match=expected_message):
+        print("test_input = {!r}".format(test_input))
         ujson.loads(test_input)
 
 
 @pytest.mark.parametrize(
-    "test_input, expected_exception, expected_message",
+    "test_input, expected_message",
     [
-        ("NaNaNaN", ujson.JSONDecodeError, "Trailing data"),
-        ("Infinity and Beyond", ujson.JSONDecodeError, "Trailing data"),
-        ("-Infinity-and-Beyond", ujson.JSONDecodeError, "Trailing data"),
-        ("NaN!", ujson.JSONDecodeError, "Trailing data"),
-        ("Infinity!", ujson.JSONDecodeError, "Trailing data"),
-        ("-Infinity!", ujson.JSONDecodeError, "Trailing data"),
+        ("NaNaNaN", "Trailing data"),
+        ("Infinity and Beyond", "Trailing data"),
+        ("-Infinity-and-Beyond", "Trailing data"),
+        ("NaN!", "Trailing data"),
+        ("Infinity!", "Trailing data"),
+        ("-Infinity!", "Trailing data"),
     ],
 )
-def test_overcomplete_special_inputs(test_input, expected_exception, expected_message):
-    with pytest.raises(expected_exception, match=expected_message):
+def test_overcomplete_special_inputs(test_input, expected_message):
+    with pytest.raises(ujson.JSONDecodeError, match=expected_message):
         ujson.loads(test_input)
 
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -723,7 +723,7 @@ def test_special_singletons():
 )
 def test_incomplete_special_inputs(test_input, expected_exception, expected_message):
     with pytest.raises(expected_exception, match=expected_message):
-        print("test_input = {!r}".format(test_input))
+        print(f"test_input = {test_input!r}")
         ujson.loads(test_input)
 
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -723,7 +723,7 @@ def test_special_singletons():
 )
 def test_incomplete_special_inputs(test_input, expected_message):
     with pytest.raises(ujson.JSONDecodeError, match=expected_message):
-        print("test_input = {!r}".format(test_input))
+        print(f"test_input = {test_input!r}")
         ujson.loads(test_input)
 
 


### PR DESCRIPTION
Fixes #146

This ports the changes from pandas (https://github.com/pandas-dev/pandas/pull/30295/files
) mentioned by @WillAyd in #146 back to ujson. 

Thus far I've only done a nearly verbatim port of the diff. There seems to be an issue. Currently:

```
python -c "import ujson; print(ujson.loads('[ true, false,null]'))"
```

is printing

```
[True, inf, -inf]
```

Also 

```
python -c "import ujson; print(ujson.loads('[Infinity, NaN, -Infinity]'))"
```

is returning 

```
[False, -inf, None]
```

So there are some details missing from the direct patch. I'll try and check for them, but my C is much worse than my Python, so any insights would be helpful.

# EDIT

I've fixed the above issue, although I'm not sure why the ordering of the function pointers in ultrajson.h `__JSONObjectDecoder` was important. I assume it's a C thing, if anyone wants to tell me why that fixed worked, I'd like to know. 

While working on this I discovered a (hidden) bug in the pandas port. When they parse NaN in C, they actually return None instead of NaN. The pandas part after that seems to interpret None as Nan, which is why their test passes:

```python
import pandas as pd
open('foo.json', 'w').write('[NaN]')
pd.read_json('foo.json')
Out[3]: 
    0
0 NaN
```

But the parser itself is actually wrong
```python
from  pandas._libs import json as pd_ujson
pd_ujson.loads('[NaN]')
Out[10]: [None]
```

And that can be demonstrated by adding a dict to the list, which prevents the pandas engine from realizing that None should have been a nan. This probably needs to be a pandas bug report ([see here](https://github.com/pandas-dev/pandas/pull/46628)).
```
open('foo.json', 'w').write('[NaN, 2, 3, {}]')
pd.read_json('foo.json')
Out[12]: 
      0
0  None
1     2
2     3
3    {}
```

But I think I can fix it here. I'm getting a handle on how this is working. 