### PR TITLE
Fix memory leak dumping on non-string dict keys

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -254,14 +254,12 @@ static int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc)
       return 1;
     }
 
+    itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
+    Py_DECREF(itemNameTmp);
     itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String (GET_TC(tc)->itemName);
     Py_DECREF(itemNameTmp);
-  }
-  else
-  {
-    Py_INCREF(GET_TC(tc)->itemName);
   }
   PRINTMARK();
   return 1;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -239,11 +239,11 @@ def test_encode_dict_values_ref_counting():
 @pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"), reason="PyPy uses incompatible GC"
 )
-def test_encode_dict_key_ref_counting():
+@pytest.mark.parametrize("key", ["key", b"key", 1, True, None])
+def test_encode_dict_key_ref_counting(key):
     import gc
 
     gc.collect()
-    key = "key"
     data = {key: "abc"}
     ref_count = sys.getrefcount(key)
     ujson.dumps(data)


### PR DESCRIPTION
For `bytes`, there was an extraneous `INCREF`; `PyIter_Next` returns a new reference. For other non-strings, the original `itemName` before converting to a string was never dereferenced.

Fixes #419