### PR TITLE
Benchmark refactor - argparse CLI

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -144,6 +144,9 @@ def results_output_table(libraries):
                     columns[i + 1] = " " * (column_widths[i + 1] + 2)
             print("|{}|".format("|".join(columns)))
 
+    print()
+    print('Above metrics are in call/sec, larger is better.')
+
 
 # =============================================================================
 # JSON encoding.

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -457,21 +457,7 @@ def main():
         help=("Specify as a fraction speed up benchmarks for development / testing"),
     )
 
-    parser.add_argument(
-        "command",
-        nargs="?",
-        help=(
-            "Exists for backwards compatibility. "
-            'Can be "skip-lib-comps" to disable computing benchmarks '
-            "for other json libraries."
-        ),
-        default=None,
-    )
-
     args = parser.parse_args()
-
-    if args.command == "skip-lib-comps":
-        args.disable.extend(known_libraries[1:])
 
     disabled_libraires = set(args.disable)
     enabled_libraries = {}

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -7,7 +7,6 @@ import sys
 import timeit
 from collections import defaultdict
 
-import cpuinfo
 import ujson
 
 # Will be set by "main" if user requests them
@@ -82,12 +81,10 @@ def results_record_result(callback, is_encode, count):
 
 def results_output_table(libraries):
     uname_system, _, uname_release, uname_version, _, uname_processor = platform.uname()
-    cpu_brand = cpuinfo.get_cpu_info()["brand_raw"]
     print()
     print("### Test machine")
     print()
     print(uname_system, uname_release, uname_processor, uname_version)
-    print(cpu_brand)
     print()
     print("### Versions")
     print()

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,5 +1,4 @@
 ﻿# coding=UTF-8
-import cpuinfo
 import json
 import os
 import platform
@@ -7,6 +6,8 @@ import random
 import sys
 import timeit
 from collections import defaultdict
+
+import cpuinfo
 import ujson
 
 # Will be set by "main" if user requests them
@@ -40,10 +41,12 @@ benchmark_registry = defaultdict(dict)
 # Benchmark registration
 # =============================================================================
 
+
 def register_benchmark(libname, testname):
     def _wrap(func):
         benchmark_registry[testname][libname] = func
         return func
+
     return _wrap
 
 
@@ -79,7 +82,7 @@ def results_record_result(callback, is_encode, count):
 
 def results_output_table(libraries):
     uname_system, _, uname_release, uname_version, _, uname_processor = platform.uname()
-    cpu_brand = cpuinfo.get_cpu_info()['brand_raw']
+    cpu_brand = cpuinfo.get_cpu_info()["brand_raw"]
     print()
     print("### Test machine")
     print()
@@ -149,30 +152,30 @@ def results_output_table(libraries):
 # JSON encoding.
 # =============================================================================
 
-_testname = 'dumps'
+_testname = "dumps"
 
 
-@register_benchmark('json', _testname)
+@register_benchmark("json", _testname)
 def dumps_with_json():
     json.dumps(test_object)
 
 
-@register_benchmark('nujson', _testname)
+@register_benchmark("nujson", _testname)
 def dumps_with_nujson():
     nujson.dumps(test_object)
 
 
-@register_benchmark('orjson', _testname)
+@register_benchmark("orjson", _testname)
 def dumps_with_orjson():
     orjson.dumps(test_object)
 
 
-@register_benchmark('simplejson', _testname)
+@register_benchmark("simplejson", _testname)
 def dumps_with_simplejson():
     simplejson.dumps(test_object)
 
 
-@register_benchmark('ujson', _testname)
+@register_benchmark("ujson", _testname)
 def dumps_with_ujson():
     ujson.dumps(test_object, ensure_ascii=False)
 
@@ -181,30 +184,30 @@ def dumps_with_ujson():
 # JSON encoding with sort_keys=True.
 # =============================================================================
 
-_testname = 'dumps-sort_keys=True'
+_testname = "dumps-sort_keys=True"
 
 
-@register_benchmark('json', _testname)
+@register_benchmark("json", _testname)
 def dumps_sorted_with_json():
     json.dumps(test_object, sort_keys=True)
 
 
-@register_benchmark('simplejson', _testname)
+@register_benchmark("simplejson", _testname)
 def dumps_sorted_with_simplejson():
     simplejson.dumps(test_object, sort_keys=True)
 
 
-@register_benchmark('nujson', _testname)
+@register_benchmark("nujson", _testname)
 def dumps_sorted_with_nujson():
     nujson.dumps(test_object, sort_keys=True)
 
 
-@register_benchmark('orjson', _testname)
+@register_benchmark("orjson", _testname)
 def dumps_sorted_with_orjson():
     orjson.dumps(test_object, sort_keys=True)
 
 
-@register_benchmark('ujson', _testname)
+@register_benchmark("ujson", _testname)
 def dumps_sorted_with_ujson():
     ujson.dumps(test_object, ensure_ascii=False, sort_keys=True)
 
@@ -213,30 +216,30 @@ def dumps_sorted_with_ujson():
 # JSON decoding.
 # =============================================================================
 
-_testname = 'loads'
+_testname = "loads"
 
 
-@register_benchmark('json', _testname)
+@register_benchmark("json", _testname)
 def loads_with_json():
     json.loads(decode_data)
 
 
-@register_benchmark('nujson', _testname)
+@register_benchmark("nujson", _testname)
 def loads_with_nujson():
     nujson.loads(decode_data)
 
 
-@register_benchmark('orjson', _testname)
+@register_benchmark("orjson", _testname)
 def loads_with_orjson():
     orjson.loads(decode_data)
 
 
-@register_benchmark('simplejson', _testname)
+@register_benchmark("simplejson", _testname)
 def loads_with_simplejson():
     simplejson.loads(decode_data)
 
 
-@register_benchmark('ujson', _testname)
+@register_benchmark("ujson", _testname)
 def loads_with_ujson():
     ujson.loads(decode_data)
 
@@ -245,21 +248,21 @@ def loads_with_ujson():
 # Benchmarks.
 # =============================================================================
 def run_decode(count, libraries):
-    _testname = 'loads'
+    _testname = "loads"
     for libname in libraries:
         func = benchmark_registry[_testname][libname]
         results_record_result(func, False, count)
 
 
 def run_encode(count, libraries):
-    _testname = 'dumps'
+    _testname = "dumps"
     for libname in libraries:
         func = benchmark_registry[_testname][libname]
         results_record_result(func, True, count)
 
 
 def run_encode_sort_keys(count, libraries):
-    _testname = 'dumps-sort_keys=True'
+    _testname = "dumps-sort_keys=True"
     for libname in libraries:
         func = benchmark_registry[_testname][libname]
         results_record_result(func, True, count)
@@ -422,33 +425,48 @@ def benchmark_complex_object(libraries, factor=1):
 # Main.
 # =============================================================================
 
+
 def main():
     import argparse
     import importlib
+
     parser = argparse.ArgumentParser(
-        prog='ujson-benchmarks',
-        description='Benchmark ujson against other json implementations')
-
-    known_libraries = [
-        'ujson',
-        'nujson',
-        'orjson',
-        'simplejson',
-        'json',
-    ]
-
-    parser.add_argument('--disable', nargs='+', choices=known_libraries, help=(
-        'Remove specified libraries from the benchmarks')
+        prog="ujson-benchmarks",
+        description="Benchmark ujson against other json implementations",
     )
 
-    parser.add_argument('--factor', type=float, default=1.0, help=(
-        'Specify as a fraction speed up benchmarks for development / testing'
-    ))
+    known_libraries = [
+        "ujson",
+        "nujson",
+        "orjson",
+        "simplejson",
+        "json",
+    ]
 
-    parser.add_argument('command', nargs='?', help=(
-        'Exists for backwards compatibility. '
-        'Can be "skip-lib-comps" to disable computing benchmarks '
-        'for other json libraries.'), default=None)
+    parser.add_argument(
+        "--disable",
+        nargs="+",
+        choices=known_libraries,
+        help=("Remove specified libraries from the benchmarks"),
+    )
+
+    parser.add_argument(
+        "--factor",
+        type=float,
+        default=1.0,
+        help=("Specify as a fraction speed up benchmarks for development / testing"),
+    )
+
+    parser.add_argument(
+        "command",
+        nargs="?",
+        help=(
+            "Exists for backwards compatibility. "
+            'Can be "skip-lib-comps" to disable computing benchmarks '
+            "for other json libraries."
+        ),
+        default=None,
+    )
 
     args = parser.parse_args()
 
@@ -462,13 +480,13 @@ def main():
             try:
                 module = importlib.import_module(libname)
             except ImportError:
-                raise ImportError(f'{libname} is not available')
+                raise ImportError(f"{libname} is not available")
             else:
                 enabled_libraries[libname] = module
 
     # Ensure the modules are avilable in a the global scope
     for libname, module in enabled_libraries.items():
-        print(f'Enabled {libname} benchmarks')
+        print(f"Enabled {libname} benchmarks")
         globals()[libname] = module
 
     libraries = list(enabled_libraries.keys())

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,11 +1,13 @@
 ﻿# coding=UTF-8
 
+import cpuinfo
 import json
 import os
 import platform
 import random
 import sys
 import timeit
+from collections import defaultdict
 
 import ujson
 
@@ -31,6 +33,20 @@ if not skip_lib_comparisons:
     import simplejson
 
 benchmark_results = []
+
+
+benchmark_registry = defaultdict(dict)
+
+
+# =============================================================================
+# Benchmark registration
+# =============================================================================
+
+def register_benchmark(libname, testname):
+    def _wrap(func):
+        benchmark_registry[testname][libname] = func
+        return func
+    return _wrap
 
 
 # =============================================================================
@@ -63,14 +79,14 @@ def results_record_result(callback, is_encode, count):
     )
 
 
-def results_output_table():
-    LIBRARIES = ("ujson", "nujson", "orjson", "simplejson", "json")
-
+def results_output_table(libraries):
     uname_system, _, uname_release, uname_version, _, uname_processor = platform.uname()
+    cpu_brand = cpuinfo.get_cpu_info()['brand_raw']
     print()
     print("### Test machine")
     print()
     print(uname_system, uname_release, uname_processor, uname_version)
+    print(cpu_brand)
     print()
     print("### Versions")
     print()
@@ -79,19 +95,17 @@ def results_output_table():
             platform.python_implementation(), sys.version.replace("\n", "")
         )
     )
-    if not skip_lib_comparisons:
-        print(f"- nujson    : {nujson.__version__}")
-        print(f"- orjson    : {orjson.__version__}")
-        print(f"- simplejson: {simplejson.__version__}")
-    print(f"- ujson     : {ujson.__version__}")
+    for libname in libraries:
+        module = globals()[libname]
+        print(f"- {libname:<12} : {module.__version__}")
     print()
 
     column_widths = [max(len(r[0]) for r in benchmark_results)]
-    for library in LIBRARIES:
+    for library in libraries:
         column_widths.append(max(10, len(library)))
 
     columns = [" " * (width + 2) for width in column_widths]
-    for i, library in enumerate(LIBRARIES):
+    for i, library in enumerate(libraries):
         columns[i + 1] = (" " + library).ljust(column_widths[i + 1] + 2)
     print("|{}|".format("|".join(columns)))
 
@@ -111,7 +125,7 @@ def results_output_table():
 
         columns = [None] * len(column_widths)
         columns[0] = " encode".ljust(column_widths[0] + 2)
-        for i, library in enumerate(LIBRARIES):
+        for i, library in enumerate(libraries):
             if library in encodes:
                 columns[i + 1] = f"{encodes[library]:,.0f} ".rjust(
                     column_widths[i + 1] + 2
@@ -123,7 +137,7 @@ def results_output_table():
         if decodes:
             columns = [None] * len(column_widths)
             columns[0] = " decode".ljust(column_widths[0] + 2)
-            for i, library in enumerate(LIBRARIES):
+            for i, library in enumerate(libraries):
                 if library in decodes:
                     columns[i + 1] = f"{decodes[library]:,.0f} ".rjust(
                         column_widths[i + 1] + 2
@@ -136,22 +150,31 @@ def results_output_table():
 # =============================================================================
 # JSON encoding.
 # =============================================================================
+
+_testname = 'dumps'
+
+
+@register_benchmark('json', _testname)
 def dumps_with_json():
     json.dumps(test_object)
 
 
+@register_benchmark('nujson', _testname)
 def dumps_with_nujson():
     nujson.dumps(test_object)
 
 
+@register_benchmark('orjson', _testname)
 def dumps_with_orjson():
     orjson.dumps(test_object)
 
 
+@register_benchmark('simplejson', _testname)
 def dumps_with_simplejson():
     simplejson.dumps(test_object)
 
 
+@register_benchmark('ujson', _testname)
 def dumps_with_ujson():
     ujson.dumps(test_object, ensure_ascii=False)
 
@@ -159,22 +182,31 @@ def dumps_with_ujson():
 # =============================================================================
 # JSON encoding with sort_keys=True.
 # =============================================================================
+
+_testname = 'dumps-sort_keys=True'
+
+
+@register_benchmark('json', _testname)
 def dumps_sorted_with_json():
     json.dumps(test_object, sort_keys=True)
 
 
+@register_benchmark('simplejson', _testname)
 def dumps_sorted_with_simplejson():
     simplejson.dumps(test_object, sort_keys=True)
 
 
+@register_benchmark('nujson', _testname)
 def dumps_sorted_with_nujson():
     nujson.dumps(test_object, sort_keys=True)
 
 
+@register_benchmark('orjson', _testname)
 def dumps_sorted_with_orjson():
     orjson.dumps(test_object, sort_keys=True)
 
 
+@register_benchmark('ujson', _testname)
 def dumps_sorted_with_ujson():
     ujson.dumps(test_object, ensure_ascii=False, sort_keys=True)
 
@@ -182,22 +214,31 @@ def dumps_sorted_with_ujson():
 # =============================================================================
 # JSON decoding.
 # =============================================================================
+
+_testname = 'loads'
+
+
+@register_benchmark('json', _testname)
 def loads_with_json():
     json.loads(decode_data)
 
 
+@register_benchmark('nujson', _testname)
 def loads_with_nujson():
     nujson.loads(decode_data)
 
 
+@register_benchmark('orjson', _testname)
 def loads_with_orjson():
     orjson.loads(decode_data)
 
 
+@register_benchmark('simplejson', _testname)
 def loads_with_simplejson():
     simplejson.loads(decode_data)
 
 
+@register_benchmark('ujson', _testname)
 def loads_with_ujson():
     ujson.loads(decode_data)
 
@@ -205,54 +246,48 @@ def loads_with_ujson():
 # =============================================================================
 # Benchmarks.
 # =============================================================================
-def run_decode(count):
-    results_record_result(loads_with_ujson, False, count)
-    if not skip_lib_comparisons:
-        results_record_result(loads_with_simplejson, False, count)
-        results_record_result(loads_with_nujson, False, count)
-        results_record_result(loads_with_orjson, False, count)
-        results_record_result(loads_with_json, False, count)
+def run_decode(count, libraries):
+    _testname = 'loads'
+    for libname in libraries:
+        func = benchmark_registry[_testname][libname]
+        results_record_result(func, False, count)
 
 
-def run_encode(count):
-    results_record_result(dumps_with_ujson, True, count)
-    if not skip_lib_comparisons:
-        results_record_result(dumps_with_simplejson, True, count)
-        results_record_result(dumps_with_nujson, True, count)
-        results_record_result(dumps_with_orjson, True, count)
-        results_record_result(dumps_with_json, True, count)
+def run_encode(count, libraries):
+    _testname = 'dumps'
+    for libname in libraries:
+        func = benchmark_registry[_testname][libname]
+        results_record_result(func, True, count)
 
 
-def run_encode_sort_keys(count):
-    results_record_result(dumps_sorted_with_ujson, True, count)
-    if not skip_lib_comparisons:
-        results_record_result(dumps_sorted_with_simplejson, True, count)
-        results_record_result(dumps_sorted_with_nujson, True, count)
-        results_record_result(dumps_sorted_with_orjson, True, count)
-        results_record_result(dumps_sorted_with_json, True, count)
+def run_encode_sort_keys(count, libraries):
+    _testname = 'dumps-sort_keys=True'
+    for libname in libraries:
+        func = benchmark_registry[_testname][libname]
+        results_record_result(func, True, count)
 
 
-def benchmark_array_doubles():
+def benchmark_array_doubles(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Array with 256 doubles")
-    COUNT = 10000
+    COUNT = max(int(10000 * factor), 1)
 
     test_object = []
     for x in range(256):
         test_object.append(sys.maxsize * random.random())
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_array_utf8_strings():
+def benchmark_array_utf8_strings(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Array with 256 UTF-8 strings")
-    COUNT = 2000
+    COUNT = max(int(2000 * factor), 1)
 
     test_object = []
     for x in range(256):
@@ -261,36 +296,36 @@ def benchmark_array_utf8_strings():
             "في الذكور من ذرية السيد تركي بن سعيد بن سلطان ويشترط فيمن يختار لولاية"
             " الحكم من بينهم ان يكون مسلما رشيدا عاقلا ًوابنا شرعيا لابوين عمانيين "
         )
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_array_byte_strings():
+def benchmark_array_byte_strings(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Array with 256 strings")
-    COUNT = 10000
+    COUNT = max(int(10000 * factor), 1)
 
     test_object = []
     for x in range(256):
         test_object.append("A pretty long string which is in a list")
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_medium_complex_object():
+def benchmark_medium_complex_object(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Medium complex object")
-    COUNT = 5000
+    COUNT = max(int(5000 * factor), 1)
 
     test_object = [
         [USER, FRIENDS],
@@ -300,53 +335,53 @@ def benchmark_medium_complex_object():
         [USER, FRIENDS],
         [USER, FRIENDS],
     ]
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_array_true_values():
+def benchmark_array_true_values(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Array with 256 True values")
-    COUNT = 50000
+    COUNT = max(int(50000 * factor), 1)
 
     test_object = []
     for x in range(256):
         test_object.append(True)
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_array_of_dict_string_int_pairs():
+def benchmark_array_of_dict_string_int_pairs(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Array with 256 dict{string, int} pairs")
-    COUNT = 5000
+    COUNT = max(int(5000 * factor), 1)
 
     test_object = []
     for x in range(256):
         test_object.append({str(random.random() * 20): int(random.random() * 1000000)})
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
 
-def benchmark_dict_of_arrays_of_dict_string_int_pairs():
+def benchmark_dict_of_arrays_of_dict_string_int_pairs(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Dict with 256 arrays with 256 dict{string, int} pairs")
-    COUNT = 50
+    COUNT = max(int(50 * factor), 1)
 
     test_object = {}
     for y in range(256):
@@ -354,33 +389,33 @@ def benchmark_dict_of_arrays_of_dict_string_int_pairs():
         for x in range(256):
             arrays.append({str(random.random() * 20): int(random.random() * 1000000)})
         test_object[str(random.random() * 20)] = arrays
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
     results_new_benchmark(
         "Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys"
     )
-    run_encode_sort_keys(COUNT)
+    run_encode_sort_keys(COUNT, libraries)
 
     test_object = None
 
 
-def benchmark_complex_object():
+def benchmark_complex_object(libraries, factor=1):
     global decode_data, test_object
     results_new_benchmark("Complex object")
-    COUNT = 100
+    COUNT = int(100 * factor)
 
     with open(os.path.join(os.path.dirname(__file__), "sample.json")) as f:
         test_object = json.load(f)
-    run_encode(COUNT)
+    run_encode(COUNT, libraries)
 
     decode_data = json.dumps(test_object)
     test_object = None
-    run_decode(COUNT)
+    run_decode(COUNT, libraries)
 
     decode_data = None
 
@@ -388,16 +423,36 @@ def benchmark_complex_object():
 # =============================================================================
 # Main.
 # =============================================================================
-if __name__ == "__main__":
-    if len(sys.argv) > 1 and "skip-lib-comps" in sys.argv:
-        skip_lib_comparisons = True
 
-    benchmark_array_doubles()
-    benchmark_array_utf8_strings()
-    benchmark_array_byte_strings()
-    benchmark_medium_complex_object()
-    benchmark_array_true_values()
-    benchmark_array_of_dict_string_int_pairs()
-    benchmark_dict_of_arrays_of_dict_string_int_pairs()
-    benchmark_complex_object()
-    results_output_table()
+def main():
+    if len(sys.argv) > 1 and "skip-lib-comps" in sys.argv:
+        # skip_lib_comparisons = True
+        libraries = (
+            "ujson",
+        )
+    else:
+        libraries = (
+            "ujson",
+            "nujson",
+            "orjson",
+            "simplejson",
+            "json"
+        )
+
+    # Set to a fraction to speed up benchmarks for development / testing
+    factor = 1.0
+
+    benchmark_array_doubles(libraries, factor)
+    benchmark_array_utf8_strings(libraries, factor)
+    benchmark_array_byte_strings(libraries, factor)
+    benchmark_medium_complex_object(libraries, factor)
+    benchmark_array_true_values(libraries, factor)
+    benchmark_array_of_dict_string_int_pairs(libraries, factor)
+    benchmark_dict_of_arrays_of_dict_string_int_pairs(libraries, factor)
+    benchmark_complex_object(libraries, factor)
+
+    results_output_table(libraries)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -148,7 +148,7 @@ def results_output_table(libraries):
             print("|{}|".format("|".join(columns)))
 
     print()
-    print('Above metrics are in call/sec, larger is better.')
+    print("Above metrics are in call/sec, larger is better.")
 
 
 # =============================================================================


### PR DESCRIPTION
@bwoodsend This is a paired down version of #532 that is ready for review / merging. There are two main features added here:

1. ~Uses the standard library's `cpuinfo` module to print CPU details when reporting the results of the benchmarks. This will help ensure that users don't compare incomparable data and can serve as a reminder for what benchmarks can be compared against each other.~ (whoops)

2. Adds an argparse CLI so the user can specify specific modules to disable. I personally don't care about the other json modules that aren't a drop-in replacement for Python's json module. Also the user can specify a `--factor` as a fraction to speed up the benchmarks for easier hacking.

To add these two features I had to do a little bit of refactoring. I wanted to make it easy to add / remove any new implementation that might come onto the scene, so I registered each benchmark with it's associated library name using a decorator and am passing the list of library names that the user requested to test to the benchmark functions. (I was very tempted to factor out the global variables but I restrained myself).

Speaking of global variables, I made it such that the external libraries aren't imported until the script knows they are needed. I use `importlib` to implement this as a loop, and then I set those modules as global variables so the rest of the benchmark structure can work without modification.

Lastly, I added a note about what units the benchmarks were in, because I always confuse myself with that. 