### PR TITLE
Remove redundant `wheel` dependency from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 
 [tool.black]
 target_version = ["py37"]


### PR DESCRIPTION
The `wheel` dependency in `pyproject.toml` is not necessary, and modern setuptools documentation advises against adding it.  The PEP517 backend automatically exposes the `wheel` dependency, and a future version of setuptools may no longer use it.

A couple of references:

* https://github.com/pypa/setuptools_scm/pull/689
* https://github.com/pypa/setuptools/pull/3056

Committed via https://github.com/asottile/all-repos