### PR TITLE
Remove redundant wheel dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 
 [tool.black]
 target_version = ["py37"]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos