### PR TITLE
Test Python 3.11 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
         exclude:
           - { python-version: "pypy-3.8", os: macos-latest }


### PR DESCRIPTION
[Python 3.11.0 beta 1 has been released 🚀](https://discuss.python.org/t/python-3-11-0b1-is-now-available/15602?u=hugovk)

This means it's now time for projects to start testing 3.11:

> We **strongly encourage** maintainers of third-party Python projects to test with 3.11 during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Monday, 2021-08-02). Our goal is have no ABI changes after beta 4 and as few code changes as possible after 3.11.0rc1, the first release candidate. To achieve that, it will be **extremely important** to get as much exposure for 3.11 as possible during the beta phase.

On [GitHub Actions](https://github.com/actions/setup-python#available-versions-of-python), `3.11-dev` tracks the latest available alpha/beta/RC.

Let's start testing now. Wheels can come later, perhaps during the release candidate phase or after beta 4.
