### PR TITLE
Fix Travis CI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/ujson.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/ujson)
 [![PyPI downloads](https://img.shields.io/pypi/dm/ujson.svg)](https://pypistats.org/packages/ujson)
 [![GitHub Actions status](https://github.com/ultrajson/ultrajson/workflows/Test/badge.svg)](https://github.com/ultrajson/ultrajson/actions)
-[![Travis CI status](https://travis-ci.com/ultrajson/ultrajson.svg?branch=main)](https://travis-ci.com/ultrajson/ultrajson)
+[![Travis CI status](https://travis-ci.com/ultrajson/ultrajson.svg?branch=main)](https://app.travis-ci.com/github/ultrajson/ultrajson)
 [![codecov](https://codecov.io/gh/ultrajson/ultrajson/branch/main/graph/badge.svg)](https://codecov.io/gh/ultrajson/ultrajson)
 [![DOI](https://zenodo.org/badge/1418941.svg)](https://zenodo.org/badge/latestdoi/1418941)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 - [ ] Get `main` to the appropriate code release state.
       [GitHub Actions](https://github.com/ultrajson/ultrajson/actions) and
-      [Travis CI](https://travis-ci.com/ultrajson/ultrajson) should be running
+      [Travis CI](https://app.travis-ci.com/github/ultrajson/ultrajson) should be running
       cleanly for all merges to `main`.
       [![GitHub Actions status](https://github.com/ultrajson/ultrajson/workflows/Test/badge.svg)](https://github.com/ultrajson/ultrajson/actions)
       [![Build Status](https://app.travis-ci.com/ultrajson/ultrajson.svg?branch=main)](https://app.travis-ci.com/ultrajson/ultrajson)


### PR DESCRIPTION
`https://travis-ci.com/ultrajson/ultrajson` -> `https://app.travis-ci.com/github/ultrajson/ultrajson`

Looks like Travis has retired the former without putting in redirects 🤷