### PR TITLE
Fix wrap around issues on large numerics

### DIFF
--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -171,7 +171,7 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds
           }
           else if (intNeg == -1)
           {
-            return SetError(ds, -1, overflowLimit == LLONG_MAX ? "Value is too big!" : "Value is too small!");
+            return SetError(ds, -1, overflowLimit == LLONG_MAX ? "Value is too big" : "Value is too small");
           }
         }
         goto BREAK_INT_LOOP;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1055,3 +1055,18 @@ if __name__ == '__main__':
         heap = hp.heapu()
         print(heap)
 """
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        ("33333333303333333333"),
+        ("18446744073709551616"),   # 64 bit
+        ("-18446744073709551616"),   # 64 bit
+        ("-80888888888888888888"),
+    ],
+)
+def test_decode_big_numeric(test_input):
+    with pytest.raises(ujson.JSONDecodeError):
+        ujson.loads(test_input)
+

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1061,12 +1061,11 @@ if __name__ == '__main__':
     "test_input",
     [
         ("33333333303333333333"),
-        ("18446744073709551616"),   # 64 bit
-        ("-18446744073709551616"),   # 64 bit
+        ("18446744073709551616"),  # 64 bit
+        ("-18446744073709551616"),  # 64 bit
         ("-80888888888888888888"),
     ],
 )
 def test_decode_big_numeric(test_input):
     with pytest.raises(ujson.JSONDecodeError):
         ujson.loads(test_input)
-


### PR DESCRIPTION
There seemed to be a mistake on LLONG_MAX vs ULLONG_MAX (the latter is
the maximum value for an object of type `unsigned long long int` which
JSUINT64 should be). I fixed that.

I am unsure about how much performance is lost on the check for overflow
on digit check...

Fixes #440

Changes proposed in this pull request:

* improve wrap around detection
* add test for wrap arounds
* make error messages more consistent (add ! at the end)
