### PR TITLE
Integer parsing: always detect overflows

### DIFF
--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -115,7 +115,7 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds
     {
       goto DECODE_INF;
     }
-    maxIntValue = -(JSUINT64) LONG_MIN;
+    maxIntValue = -(JSUINT64) LLONG_MIN;
     overflowLimit = maxIntValue / 10LL;
   }
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -592,7 +592,10 @@ def test_decode_range_raises(test_input, expected):
         ("[]]", ujson.JSONDecodeError),  # array unmatched bracket fail
         ("18446744073709551616", ujson.JSONDecodeError),  # too big value
         ("-90223372036854775809", ujson.JSONDecodeError),  # too small value
+        ("-23058430092136939529", ujson.JSONDecodeError),  # too small value
+        ("-11529215046068469760", ujson.JSONDecodeError),  # too small value
         ("18446744073709551616", ujson.JSONDecodeError),  # very too big value
+        ("23058430092136939529", ujson.JSONDecodeError),  # too big value
         ("-90223372036854775809", ujson.JSONDecodeError),  # very too small value
         ("{}\n\t a", ujson.JSONDecodeError),  # with trailing non whitespaces
         ("[18446744073709551616]", ujson.JSONDecodeError),  # array with big int


### PR DESCRIPTION
Fixes #440 

The current logic for detecting overflows while parsing large integer only detects some overflows. Each calculation like multiplication and addition has to be verified to be in bounds because otherwise it might silently overflow.

This PR fixes overflow detection and out of bounds checks for integer numbers with large absolute value. It replaces the current bounds checking and overflow checking logic.
The implementation should be quite efficient because the checks only use additions and comparisons of 64bit integers in the parsing loop and it handles negative numbers without additional checks. Furthermore it correctly parses LLONG_MIN on 2s complement architectures, where -LLONG_MIN - 1 = LLONG_MAX should be satisfied. I haven't added a test for this because there is no guarantee that it will work on all architectures, i.e. -LLONG_MIN = LLONG_MAX is also possible. Maybe a test should be added because basically all CPUs use 2s complement representation of signed integers.

PR #543 seems to use a similar idea, but I only noticed it after writing the patch. It uses divisions in the parsing loop and I'm not sure whether it would parse all negative integers correctly.

Changes proposed in this pull request:
- add tests which fail with the current implementation
- fix overflow detection while parsing integer numbers
- make error messages consistent when parsing too large or too small numbers
- change the formatting of head of function
