### PR TITLE
Reduce CI matrix: test Ubuntu on all Pythons, and the others on a single Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
-        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-2019]
-        exclude:
-          - { python-version: "pypy-3.8", os: macos-latest }
+        os: [ubuntu-latest]
+        include:
+          - { python-version: "3.10", os: windows-latest }
+          - { python-version: "3.10", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,11 @@ jobs:
           coverage run -m pytest
           ./scripts/coverage.sh
           bash <(curl -s https://codecov.io/bash) -X gcov
+
+  success:
+    needs: test
+    runs-on: ubuntu-latest
+    name: test successful
+    steps:
+      - name: Success
+        run: echo Test successful

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -745,7 +745,6 @@ def test_special_singletons():
 )
 def test_incomplete_special_inputs(test_input, expected_message):
     with pytest.raises(ujson.JSONDecodeError, match=expected_message):
-        print(f"test_input = {test_input!r}")
         ujson.loads(test_input)
 
 


### PR DESCRIPTION
Fixes #546.

Changes proposed in this pull request:

* Test Ubuntu with all Python versions
* And test Windows and macOS with a single Python version
* Also remove a stray `print` from a test

# Before

23 jobs

![image](https://user-images.githubusercontent.com/1324225/171652367-39d852ab-ad31-4665-a955-237340a14637.png)

# After

8 jobs

![image](https://user-images.githubusercontent.com/1324225/171652293-eb8245db-848a-4bde-83f8-b31f80671bd7.png)

