### PR TITLE
Add support for arbitrary size integers

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -332,6 +332,7 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newInt)(void *prv, JSINT32 value);
   JSOBJ (*newLong)(void *prv, JSINT64 value);
   JSOBJ (*newUnsignedLong)(void *prv, JSUINT64 value);
+  JSOBJ (*newIntegerFromString)(void *prv, char *value, size_t length);
   JSOBJ (*newDouble)(void *prv, double value);
   void (*releaseObject)(void *prv, JSOBJ obj);
   JSPFN_MALLOC malloc;

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -173,7 +173,10 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds
       {
         if (hasError)
         {
-          return SetError(ds, -1, intNeg == 1 ? "Value is too big" : "Value is too small");
+          char *strStart = ds->start;
+          ds->lastType = JT_INT;
+          ds->start = offset;
+          return ds->dec->newIntegerFromString(ds->prv, strStart, offset - strStart);
         }
         goto BREAK_INT_LOOP;
         break;

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -119,6 +119,15 @@ static JSOBJ Object_newUnsignedLong(void *prv, JSUINT64 value)
   return PyLong_FromUnsignedLongLong (value);
 }
 
+static JSOBJ Object_newIntegerFromString(void *prv, char *value, size_t length)
+{
+  // PyLong_FromString requires a NUL-terminated string in CPython, contrary to the documentation: https://github.com/python/cpython/issues/59200
+  char *buf = PyObject_Malloc(length + 1);
+  memcpy(buf, value, length);
+  buf[length] = '\0';
+  return PyLong_FromString(buf, NULL, 10);
+}
+
 static JSOBJ Object_newDouble(void *prv, double value)
 {
   return PyFloat_FromDouble(value);
@@ -152,6 +161,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newInteger,
     Object_newLong,
     Object_newUnsignedLong,
+    Object_newIntegerFromString,
     Object_newDouble,
     Object_releaseObject,
     PyObject_Malloc,

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -620,6 +620,8 @@ def test_encode_decode_big_int(i, mode):
                 # https://foss.heptapod.net/pypy/pypy/-/issues/3765
                 pytest.skip("PyPy can't serialise big ints")
             assert ujson.encode(py) == j
+            if isinstance(py, dict):
+                assert ujson.encode(py, sort_keys=True) == j
         else:
             assert ujson.decode(j) == py
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -601,6 +601,23 @@ def test_decode_numeric_int_exp(test_input):
 
 
 @pytest.mark.parametrize(
+    "i",
+    [
+        -(10**25),  # very negative
+        -(2**64),  # too large in magnitude for a uint64
+        -(2**63) - 1,  # too small for a int64
+        2**64,  # too large for a uint64
+        10**25,  # very positive
+    ],
+)
+def test_encode_decode_big_int(i):
+    # Test ints that are too large to be represented by a C integer type
+    for py, j in ((i, str(i)), ([i], f"[{i}]"), ({"i": i}, f'{{"i":{i}}}')):
+        assert ujson.encode(py) == j
+        assert ujson.decode(j) == py
+
+
+@pytest.mark.parametrize(
     "test_input, expected",
     [
         ('{{1337:""}}', ujson.JSONDecodeError),  # broken dict key type leak test
@@ -636,15 +653,7 @@ def test_decode_range_raises(test_input, expected):
         ("[,31337]", ujson.JSONDecodeError),  # array leading comma fail
         ("[,]", ujson.JSONDecodeError),  # array only comma fail
         ("[]]", ujson.JSONDecodeError),  # array unmatched bracket fail
-        ("18446744073709551616", ujson.JSONDecodeError),  # too big value
-        ("-90223372036854775809", ujson.JSONDecodeError),  # too small value
-        ("-23058430092136939529", ujson.JSONDecodeError),  # too small value
-        ("-11529215046068469760", ujson.JSONDecodeError),  # too small value
-        ("18446744073709551616", ujson.JSONDecodeError),  # very too big value
-        ("23058430092136939529", ujson.JSONDecodeError),  # too big value
-        ("-90223372036854775809", ujson.JSONDecodeError),  # very too small value
         ("{}\n\t a", ujson.JSONDecodeError),  # with trailing non whitespaces
-        ("[18446744073709551616]", ujson.JSONDecodeError),  # array with big int
         ('{"age", 44}', ujson.JSONDecodeError),  # read bad object syntax
     ],
 )
@@ -718,11 +727,6 @@ def test_dumps_raises(test_input, expected_exception, expected_message):
         (float("nan"), OverflowError),
         (float("inf"), OverflowError),
         (-float("inf"), OverflowError),
-        (12839128391289382193812939, OverflowError),
-        ([12839128391289382193812939], OverflowError),
-        ([12839128391289382193812939, 42], OverflowError),
-        ({"a": 12839128391289382193812939}, OverflowError),
-        ({"a": 12839128391289382193812939, "b": 42}, OverflowError),
     ],
 )
 def test_encode_raises_allow_nan(test_input, expected_exception):

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -613,17 +613,17 @@ def test_decode_numeric_int_exp(test_input):
 @pytest.mark.parametrize("mode", ["encode", "decode"])
 def test_encode_decode_big_int(i, mode):
     # Test ints that are too large to be represented by a C integer type
-    for py in (i, [i], {"i": i}):
-        j = json.dumps(py, separators=(",", ":"))
+    for python_object in (i, [i], {"i": i}):
+        json_string = json.dumps(python_object, separators=(",", ":"))
         if mode == "encode":
             if hasattr(sys, "pypy_version_info"):
                 # https://foss.heptapod.net/pypy/pypy/-/issues/3765
                 pytest.skip("PyPy can't serialise big ints")
-            assert ujson.encode(py) == j
-            if isinstance(py, dict):
-                assert ujson.encode(py, sort_keys=True) == j
+            assert ujson.encode(python_object) == json_string
+            if isinstance(python_object, dict):
+                assert ujson.encode(python_object, sort_keys=True) == json_string
         else:
-            assert ujson.decode(j) == py
+            assert ujson.decode(json_string) == python_object
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -613,7 +613,8 @@ def test_decode_numeric_int_exp(test_input):
 @pytest.mark.parametrize("mode", ["encode", "decode"])
 def test_encode_decode_big_int(i, mode):
     # Test ints that are too large to be represented by a C integer type
-    for py, j in ((i, str(i)), ([i], f"[{i}]"), ({"i": i}, f'{{"i":{i}}}')):
+    for py in (i, [i], {"i": i}):
+        j = json.dumps(py, separators=(",", ":"))
         if mode == "encode":
             if hasattr(sys, "pypy_version_info"):
                 # https://foss.heptapod.net/pypy/pypy/-/issues/3765

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -610,11 +610,17 @@ def test_decode_numeric_int_exp(test_input):
         10**25,  # very positive
     ],
 )
-def test_encode_decode_big_int(i):
+@pytest.mark.parametrize("mode", ["encode", "decode"])
+def test_encode_decode_big_int(i, mode):
     # Test ints that are too large to be represented by a C integer type
     for py, j in ((i, str(i)), ([i], f"[{i}]"), ({"i": i}, f'{{"i":{i}}}')):
-        assert ujson.encode(py) == j
-        assert ujson.decode(j) == py
+        if mode == "encode":
+            if hasattr(sys, "pypy_version_info"):
+                # https://foss.heptapod.net/pypy/pypy/-/issues/3765
+                pytest.skip("PyPy can't serialise big ints")
+            assert ujson.encode(py) == j
+        else:
+            assert ujson.decode(j) == py
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This implements the idea I mentioned in #440: when an int is too large to be handled with C integers, do the conversion with Python's C functions instead and treat it as a char array internally.

The code already works, but it's obviously not ready for merging. I'm submitting it now for feedback.

---

I only looked at performance briefly so far. As the code is now, it shouldn't noticeably impact throughput when no large ints are in the input (just one additional jump on encoding and a bigger jump on decoding, I think). Given how complex they are compared to ujson's implementation, I was surprised to find that the CPython functions actually perform very well. On encoding, with some simple `python3 -m timeit -s 'import ujson' 'ujson.dumps(i)'` tests, I found the following:

`i` | time | note
-|-|-
`0` | 255 ns |
`9` | 267 ns |
`10` | 280 ns |
`256` | 282 ns |
`257` | 282 ns | Not interned, clearly the creation of new `int` objects is not relevant.
`65536` | 289 ns |
`9223372036854775807` (`2**63-1`) | 337 ns | Last value to make use of the `long long`
`9223372036854775808` | 501 ns |
`18446744073709551615` (`2**64-1`) | 503 ns | Last value to make use of the `unsigned long long`
`18446744073709551616` | 504 ns | First value to make use of this new implementation

I also briefly looked into getting rid of the `PyLong_AsLongLong` and `PyLong_AsUnsignedLongLong` calls entirely and just using this method for everything (though I didn't clean everything up, just commented out that code in `Object_beginTypeContext`). For `]-2**63, 2**63[`, this is slower than the existing code. (The range `[-9, 9]` is marginally faster because CPython has optimised code for that.) Outside of that range, it performs better. Specifically, `ujson.dumps(9223372036854775808)` takes about 395 ns on my machine then, 20 % less than the existing code. I haven't thoroughly tested removing only the unsigned call, but it seems to not be of any value. In other words, if someone were to encode lots of large ints, this might be a considerable performance increase for them, and if most ints were single-digit, it would be about equal. For others, it would be significantly worse. I'm not sure what to do with this insight.