### PR TITLE
Re-enable testing on PyPy for all platforms.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         include:
           - { python-version: "3.10", os: windows-latest }
           - { python-version: "3.10", os: macos-latest }
+          - { python-version: "pypy-3.8", os: windows-latest }
+          - { python-version: "pypy-3.8", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-latest]
         include:
-          - { python-version: "3.10", os: windows-latest }
-          - { python-version: "3.10", os: macos-latest }
           - { python-version: "pypy-3.8", os: windows-latest }
           - { python-version: "pypy-3.8", os: macos-latest }
+          - { python-version: "3.10", os: windows-latest }
+          - { python-version: "3.10", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -515,6 +515,10 @@ def test_encode_surrogate_characters():
     assert ujson.dumps({"\ud800": "\udfff"}, ensure_ascii=False, sort_keys=True) == out2
 
 
+@pytest.mark.xfail(
+    hasattr(sys, "pypy_version_info") and os.name == "nt",
+    reason="This feature needs fixing! See #552",
+)
 @pytest.mark.parametrize(
     "test_input, expected",
     [


### PR DESCRIPTION
- Renable CI/CD testing on PyPy for all platforms.
- xfail test_decode_surrogate_characters() on Windows PyPy.

Addresses (but doesn't fix) #552.
