### PR TITLE
Deploy workflow: Add colour to CI output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
       - published
   workflow_dispatch:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build-native-wheels:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Changes proposed in this pull request:

* Enable colour in the logs for the deploy workflow logs

# Before

<img width="643" alt="image" src="https://user-images.githubusercontent.com/1324225/174430843-374e6097-5d1b-4d9e-94e1-6633cef3af91.png">

https://github.com/ultrajson/ultrajson/runs/6924839486?check_suite_focus=true#step:6:1607

# After

<img width="653" alt="image" src="https://user-images.githubusercontent.com/1324225/174430831-7b35c38c-ad27-497a-aad9-862c02f569d9.png">

https://github.com/ultrajson/ultrajson/runs/6947141574?check_suite_focus=true#step:6:1185
