### PR TITLE
Replace `wchar_t` string decoding implementation with a `uint32_t`-based one

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -54,7 +54,6 @@ tree doesn't have cyclic references.
 #define __ULTRAJSON_H__
 
 #include <stdio.h>
-#include <wchar.h>
 
 // Max decimals to encode double floating point numbers with
 #ifndef JSON_DOUBLE_MAX_DECIMALS
@@ -318,7 +317,7 @@ EXPORTFUNCTION char *JSON_EncodeObject(JSOBJ obj, JSONObjectEncoder *enc, char *
 
 typedef struct __JSONObjectDecoder
 {
-  JSOBJ (*newString)(void *prv, wchar_t *start, wchar_t *end);
+  JSOBJ (*newString)(void *prv, JSUINT32 *start, JSUINT32 *end);
   void (*objectAddKey)(void *prv, JSOBJ obj, JSOBJ name, JSOBJ value);
   void (*arrayAddItem)(void *prv, JSOBJ obj, JSOBJ value);
   JSOBJ (*newTrue)(void *prv);

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -59,9 +59,18 @@ static void Object_arrayAddItem(void *prv, JSOBJ obj, JSOBJ value)
   return;
 }
 
-static JSOBJ Object_newString(void *prv, wchar_t *start, wchar_t *end)
+/*
+Check that Py_UCS4 is the same as JSUINT32, else Object_newString will fail.
+Based on Linux's check in vbox_vmmdev_types.h.
+This should be replaced with
+  _Static_assert(sizeof(Py_UCS4) == sizeof(JSUINT32));
+when C11 is made mandatory (CPython 3.11+, PyPy ?).
+*/
+typedef char assert_py_ucs4_is_jsuint32[1 - 2*!(sizeof(Py_UCS4) == sizeof(JSUINT32))];
+
+static JSOBJ Object_newString(void *prv, JSUINT32 *start, JSUINT32 *end)
 {
-  return PyUnicode_FromWideChar (start, (end - start));
+  return PyUnicode_FromKindAndData (PyUnicode_4BYTE_KIND, (Py_UCS4 *) start, (end - start));
 }
 
 static JSOBJ Object_newTrue(void *prv)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1,4 +1,3 @@
-import ctypes
 import datetime as dt
 import decimal
 import io
@@ -515,10 +514,6 @@ def test_encode_surrogate_characters():
     assert ujson.dumps({"\ud800": "\udfff"}, ensure_ascii=False, sort_keys=True) == out2
 
 
-@pytest.mark.xfail(
-    hasattr(sys, "pypy_version_info") and os.name == "nt",
-    reason="This feature needs fixing! See #552",
-)
 @pytest.mark.parametrize(
     "test_input, expected",
     [
@@ -543,10 +538,6 @@ def test_encode_surrogate_characters():
     ],
 )
 def test_decode_surrogate_characters(test_input, expected):
-    # FIXME Wrong output (combined char) on platforms with 16-bit wchar_t
-    if test_input == '"\uD83D\uDCA9"' and ctypes.sizeof(ctypes.c_wchar) == 2:
-        pytest.skip("Raw surrogate pairs are not supported with 16-bit wchar_t")
-
     assert ujson.loads(test_input) == expected
     assert ujson.loads(test_input.encode("utf-8", "surrogatepass")) == expected
 


### PR DESCRIPTION
This fixes character handling on platforms with 16-bit `wchar_t` (notably, Windows), which was broken (in different ways) on both CPython and PyPy.

Fixes #552

Remarks:

* For the disgusting `Py_UCS4 == JSUINT32` check magic, see the comments on #552.
* The changelog might need a little touch-up here as this is essentially a continuation of #550.
* I have not run any performance comparisons yet. In general, I would expect it to perform at least as well as the previous implementation since `PyUnicode_FromWideChar` does some extra work compared to `PyUnicode_FromKindAndData` (mostly due to surrogate handling). On 16-bit `wchar_t` platforms, the larger buffer size might have some impact though; I won't be able to run comparisons for that though, I think.