### PR TITLE
Add workflow to require changelog label for PRs

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,18 @@
+name: Require PR label
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: minimum
+          count: 1
+          labels:
+            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
+            Fixed, changelog: Removed, changelog: Security, changelog: skip"


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds a status check that fails until one of the ["changelog: X" labels](https://github.com/ultrajson/ultrajson/labels?q=changelog) is added
* It acts as a reminder so the automated Release Drafter workflow can do its thing and group PRs by category ([for example](https://github.com/ultrajson/ultrajson/releases/tag/5.3.0))
