### PR TITLE
docs: Fix a few typos

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -321,7 +321,7 @@ static int SortedDict_iterNext(JSOBJ obj, JSONTypeContext *tc)
   PyObject* keyTmp;
 
   // Upon first call, obtain a list of the keys and sort them. This follows the same logic as the
-  // stanard library's _json.c sort_keys handler.
+  // standard library's _json.c sort_keys handler.
   if (GET_TC(tc)->newObj == NULL)
   {
     // Obtain the list of keys from the dictionary.

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -639,7 +639,7 @@ def test_decode_range_raises(test_input, expected):
 @pytest.mark.parametrize(
     "test_input, expected",
     [
-        ("fdsa sda v9sa fdsa", ujson.JSONDecodeError),  # jibberish
+        ("fdsa sda v9sa fdsa", ujson.JSONDecodeError),  # gibberish
         ("[", ujson.JSONDecodeError),  # broken array start
         ("{", ujson.JSONDecodeError),  # broken object start
         ("]", ujson.JSONDecodeError),  # broken array end


### PR DESCRIPTION
There are small typos in:
- python/objToJSON.c
- tests/test_ujson.py

Fixes:
- Should read `standard` rather than `stanard`.
- Should read `gibberish` rather than `jibberish`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md