### PR TITLE
Fix encoding of infinity (#80).

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,11 @@ repos:
       - id: trailing-whitespace
         exclude: "^.github/.*_TEMPLATE.md"
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
-    hooks:
-      - id: setup-cfg-fmt
+# Disabled due to asottile/setup-cfg-fmt#73. Re-enable once that issue is fixed.
+#  - repo: https://github.com/asottile/setup-cfg-fmt
+#    rev: v1.20.1
+#    hooks:
+#      - id: setup-cfg-fmt
 
 ci:
   autoupdate_schedule: quarterly

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -887,7 +887,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   if (encoder.allowNan)
   {
-    csInf = "Inf";
+    csInf = "Infinity";
     csNan = "NaN";
   }
 

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -58,7 +58,7 @@ PyObject* JSONDecodeError;
 #define ENCODER_HELP_TEXT "Use ensure_ascii=false to output UTF-8. " \
     "Set encode_html_chars=True to encode < > & as unicode escape sequences. "\
     "Set escape_forward_slashes=False to prevent escaping / characters." \
-    "Set allow_nan=False to raise an exception when NaN or Inf would be serialized." \
+    "Set allow_nan=False to raise an exception when NaN or Infinity would be serialized." \
     "Set reject_bytes=True to raise TypeError on bytes."
 
 static PyMethodDef ujsonMethods[] = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ultrajson/ultrajson
 author = Jonas Tarnstrom
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -842,8 +842,8 @@ def test_encode_no_assert(test_input):
         (1.0, "1.0"),
         (OrderedDict([(1, 1), (0, 0), (8, 8), (2, 2)]), '{"1":1,"0":0,"8":8,"2":2}'),
         ({"a": float("NaN")}, '{"a":NaN}'),
-        ({"a": float("inf")}, '{"a":Inf}'),
-        ({"a": -float("inf")}, '{"a":-Inf}'),
+        ({"a": float("inf")}, '{"a":Infinity}'),
+        ({"a": -float("inf")}, '{"a":-Infinity}'),
     ],
 )
 def test_encode(test_input, expected):


### PR DESCRIPTION
Infinity was being encoded as 'Inf' which, whilst the JSON spec doesn't include any non-finite floats, differs from the conventions in other JSON libraries, JavaScript of using 'Infinity'. It also differs from what `ujson.loads()` expects so that `ujson.loads(ujson.dumps(math.inf))` raises an exception.
