### PR TITLE
Add support for Python 3.11 and PyPy3.9

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        architecture: ["aarch64"]
         python-version:
           - pp37
           - pp38
@@ -120,7 +119,7 @@ jobs:
         env:
           # Build only the currently selected Linux architecture (so we can
           # parallelise for speed).
-          CIBW_ARCHS_LINUX: "${{ matrix.architecture }}"
+          CIBW_ARCHS_LINUX: "aarch64"
           # Likewise, select only one Python version per job to speed this up.
           CIBW_BUILD: "${{ matrix.python-version }}-*"
           # Run the test suite after each build.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,12 +25,13 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: ".github/workflows/deploy.yml"
 
@@ -54,7 +55,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {package}/tests
 
       - name: Upload as build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -91,11 +92,11 @@ jobs:
           - cp310
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           cache: pip
           cache-dependency-path: ".github/workflows/deploy.yml"
@@ -107,11 +108,11 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
@@ -127,7 +128,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {package}/tests
 
       - name: Upload as build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -154,14 +155,14 @@ jobs:
     needs: ['build-native-wheels', 'build-QEMU-emulated-wheels']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
             git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: "setup.py"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,7 @@ jobs:
         python-version:
           - pp37
           - pp38
+          - pp39
           - cp37
           - cp38
           - cp39

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install cibuildwheel==2.3.0
+          python -m pip install cibuildwheel==2.10.0
           python -m pip install -U twine
 
       - name: Build wheels
@@ -48,8 +48,6 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           # Build only on Linux architectures that don't need qemu emulation.
           CIBW_ARCHS_LINUX: "x86_64 i686"
-          # Don't build with prerelease Python versions.
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7,<3.11"
           # Run the test suite after each build.
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: pytest {package}/tests
@@ -90,6 +88,7 @@ jobs:
           - cp38
           - cp39
           - cp310
+          - cp311
 
     steps:
       - uses: actions/checkout@v3
@@ -98,12 +97,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: ".github/workflows/deploy.yml"
 
       - name: Install dependencies
         run: |
-          python -m pip install cibuildwheel==2.3.0
+          python -m pip install cibuildwheel==2.10.0
           python -m pip install -U twine
 
       # https://github.com/docker/setup-qemu-action

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
           twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*.whl
 
   build-sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: ['build-native-wheels', 'build-QEMU-emulated-wheels']
 
     steps:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,7 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: micnncim/action-label-syncer@v1
         with:
           prune: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
           - { python-version: "3.10", os: macos-latest }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -66,7 +66,7 @@ jobs:
       matrix:
         architecture: [ppc64le, s390x, aarch64, arm/v6, 386]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --prune --unshallow
 
       # https://github.com/docker/setup-qemu-action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
           - { python-version: "pypy-3.8", os: macos-latest }
           - { python-version: "3.10", os: windows-latest }
           - { python-version: "3.10", os: macos-latest }
+          - { python-version: "3.11-dev", os: windows-latest }
+          - { python-version: "3.11-dev", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +50,7 @@ jobs:
           python -m pytest
 
       - name: Test with coverage
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.10' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 download_url = https://github.com/ultrajson/ultrajson
 project_urls =
     Source=https://github.com/ultrajson/ultrajson


### PR DESCRIPTION
Changes proposed in this pull request:

* Support Python 3.11:
  * add Trove classifier
  * test on CI
  * build wheel 
* Create wheel for PyPy3.9

[Python 3.11 is currently at release candidate 2](https://discuss.python.org/t/python-3-11-0rc2-is-now-available/18988?u=hugovk), the last one before full release on [2022-10-24](https://peps.python.org/pep-0664/#schedule), and includes this call to action:

> **Community members**
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.11 compatibilities during this phase. As always, report any issues to [the Python bug tracker 1](https://github.com/issues).

And:

> There will be no ABI changes from this point forward in the 3.11 series and the goal is that there will be as few code changes as possible.

So it is pretty safe to release a 3.11 release now. We can label it as a dev preview, and put also out a new release when 3.11.0 is out.

But also, if you'd prefer to wait until the full 3.11.0 release, that's fine too, we've not yet had anyone asking for 3.11 wheels yet.

---


Also in this PR:

* Bump GitHub Actions versions
* GHA: Use ubuntu-latest, except pin to latest 22.04 for the benchmarking