### PR TITLE
Fix len integer overflow issue

### DIFF
--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -79,6 +79,8 @@ static JSOBJ SetError( struct DecoderState *ds, int offset, const char *message)
 static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodeDouble(struct DecoderState *ds)
 {
   int processed_characters_count;
+  /* Prevent int overflow if ds->end - ds->start is too large. See check_decode_decimal_no_int_overflow()
+  inside tests/test_ujson.py for an example where this check is necessary. */
   int len = ((size_t) (ds->end - ds->start) < (size_t) INT_MAX) ? (int) (ds->end - ds->start) : INT_MAX;
   double value = dconv_s2d(ds->dec->s2d, ds->start, len, &processed_characters_count);
   ds->lastType = JT_DOUBLE;

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -79,7 +79,7 @@ static JSOBJ SetError( struct DecoderState *ds, int offset, const char *message)
 static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodeDouble(struct DecoderState *ds)
 {
   int processed_characters_count;
-  int len = (int)(ds->end - ds->start);
+  int len = ((size_t)(ds->end - ds->start) < (size_t) INT_MAX) ? (int)(ds->end - ds->start) : INT_MAX;
   double value = dconv_s2d(ds->dec->s2d, ds->start, len, &processed_characters_count);
   ds->lastType = JT_DOUBLE;
   ds->start += processed_characters_count;

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -79,7 +79,7 @@ static JSOBJ SetError( struct DecoderState *ds, int offset, const char *message)
 static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodeDouble(struct DecoderState *ds)
 {
   int processed_characters_count;
-  int len = ((size_t)(ds->end - ds->start) < (size_t) INT_MAX) ? (int)(ds->end - ds->start) : INT_MAX;
+  int len = ((size_t) (ds->end - ds->start) < (size_t) INT_MAX) ? (int) (ds->end - ds->start) : INT_MAX;
   double value = dconv_s2d(ds->dec->s2d, ds->start, len, &processed_characters_count);
   ds->lastType = JT_DOUBLE;
   ds->start += processed_characters_count;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1126,7 +1126,7 @@ def test_separators_errors(separators, expected_exception):
 
 def test_decode_decimal_no_int_overflow():
     # This unittest takes a while because the string is large; feel free to comment out or remove
-    ujson.decode(r'[0.123456789,"{}"]'.format('a' * (2**32 - 5)))
+    ujson.decode(r'[0.123456789,"{}"]'.format("a" * (2**32 - 5)))
 
 
 """

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1124,9 +1124,15 @@ def test_separators_errors(separators, expected_exception):
         ujson.dumps({"a": 0, "b": 1}, separators=separators)
 
 
-def test_decode_decimal_no_int_overflow():
-    # Takes a while because the string is large; feel free to comment out or remove
-    ujson.decode(r'[0.123456789,"{}"]'.format("a" * (2**32 - 5)))
+"""
+The following checks are not part of the standard test suite.
+They can be run manually as follows:
+python -c 'from tests.test_ujson import check_foo; check_foo()'
+"""
+def check_decode_decimal_no_int_overflow():
+    # Requires enough free RAM to hold a ~4GB string in memory
+    decoded = ujson.decode(r'[0.123456789,"{}"]'.format("a" * (2**32 - 5)))
+    assert decoded[0] == 0.123456789
 
 
 """

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1129,6 +1129,8 @@ The following checks are not part of the standard test suite.
 They can be run manually as follows:
 python -c 'from tests.test_ujson import check_foo; check_foo()'
 """
+
+
 def check_decode_decimal_no_int_overflow():
     # Requires enough free RAM to hold a ~4GB string in memory
     decoded = ujson.decode(r'[0.123456789,"{}"]'.format("a" * (2**32 - 5)))

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1124,6 +1124,11 @@ def test_separators_errors(separators, expected_exception):
         ujson.dumps({"a": 0, "b": 1}, separators=separators)
 
 
+def test_decode_decimal_no_int_overflow():
+    # This unittest takes a while because the string is large; feel free to comment out or remove
+    ujson.decode(r'[0.123456789,"{}"]'.format('a' * (2**32 - 5)))
+
+
 """
 def test_decode_numeric_int_frc_overflow():
 input = "X.Y"

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1125,7 +1125,7 @@ def test_separators_errors(separators, expected_exception):
 
 
 def test_decode_decimal_no_int_overflow():
-    # This unittest takes a while because the string is large; feel free to comment out or remove
+    # Takes a while because the string is large; feel free to comment out or remove
     ujson.decode(r'[0.123456789,"{}"]'.format("a" * (2**32 - 5)))
 
 


### PR DESCRIPTION
Bug:

If `ds->end - ds->start` causes an `int` overflow here, we may end up truncating a double while parsing. This will then cause a decoder error, as the next token will be unexpected. 

Changes proposed in this pull request:

Avoid integer overflow by setting `len = min(INT_MAX, ds->end - ds->start)` in `decodeDouble`.
