### PR TITLE
Support ujson.loads(bytearray(...)) and other bytes-like objects.

### DIFF
--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1126,7 +1126,11 @@ def test_separators_errors(separators, expected_exception):
 
 def test_loads_bytes_like():
     assert ujson.loads(b"123") == 123
-    assert ujson.loads(memoryview(b'["a", "b", "c"]')) == ["a", "b", "c"]
+    if hasattr(sys, "pypy_version_info"):
+        with pytest.raises(TypeError, match="PyPy"):
+            ujson.loads(memoryview(b"{}"))
+    else:
+        assert ujson.loads(memoryview(b'["a", "b", "c"]')) == ["a", "b", "c"]
     assert ujson.loads(bytearray(b"99")) == 99
     assert ujson.loads('"🦄🐳"'.encode()) == "🦄🐳"
 


### PR DESCRIPTION
Fixes #572

Changes proposed in this pull request:

* Generalise the support for using `ujson.loads()` on bytes to any C contiguous bytes like object such as `bytearray()`, `memoryview()` and `array.array()`.
