### PR TITLE
Add test for int- and float-derived Enums

### DIFF
--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import decimal
+import enum
 import io
 import json
 import math
@@ -1160,6 +1161,20 @@ def test_loads_non_c_contiguous():
     assert ujson.loads(bytes(buffer)) == [1, 2, 3]
     with pytest.raises(TypeError):
         ujson.loads(buffer)
+
+
+@pytest.mark.parametrize(
+    "enum_classes, value, expected",
+    [
+        ((enum.IntEnum,), 42, "42"),
+        ((float, enum.Enum), 3.1416, "3.1416"),
+    ],
+)
+def test_enum(enum_classes, value, expected):
+    class MyEnum(*enum_classes):
+        FOO = value
+
+    assert ujson.dumps(MyEnum.FOO) == expected
 
 
 """


### PR DESCRIPTION
The stdlib json module has supported these since Python 3.4. Since `enum.IntEnum` is an `int` subclass (and hence `PyLong_*` work as expected), ujson has supported them for a long time as well, but this was so far not tested.

Thanks to Hi-Angel on IRC for (inadvertently) bringing this to my attention. I had no idea previously that stdlib json supported this, nor that ujson has no problem with it.

(I strongly disagree with the formatting of the float test parameters. I initially put it all on a single line, but black says it must be like that, so it's clearly the most readable option...)