### PR TITLE
Include BSD-3-Clause and TCL license text

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -24,12 +24,91 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+----
 
 Portions of code from MODP_ASCII - Ascii transformations (upper/lower, etc)
 https://github.com/client9/stringencoders
-Copyright (c) 2007  Nick Galbreath -- nickg [at] modp [dot] com. All rights reserved.
+
+  Copyright 2005, 2006, 2007
+  Nick Galbreath -- nickg [at] modp [dot] com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+    Neither the name of the modp.com nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This is the standard "new" BSD license:
+  http://www.opensource.org/licenses/bsd-license.php
+
+https://github.com/client9/stringencoders/blob/cfd5c1507325ae497ea9bacdacba12c0ffd79d30/COPYING
+
+----
 
 Numeric decoder derived from from TCL library
 https://opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
  * Copyright (c) 1988-1993 The Regents of the University of California.
  * Copyright (c) 1994 Sun Microsystems, Inc.
+
+  This software is copyrighted by the Regents of the University of
+  California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
+  Corporation and other parties.  The following terms apply to all files
+  associated with the software unless explicitly disclaimed in
+  individual files.
+
+  The authors hereby grant permission to use, copy, modify, distribute,
+  and license this software and its documentation for any purpose, provided
+  that existing copyright notices are retained in all copies and that this
+  notice is included verbatim in any distributions. No written agreement,
+  license, or royalty fee is required for any of the authorized uses.
+  Modifications to this software may be copyrighted by their authors
+  and need not follow the licensing terms described here, provided that
+  the new terms are clearly indicated on the first page of each file where
+  they apply.
+
+  IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+  FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+  ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+  DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+  THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+  IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+  NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+  MODIFICATIONS.
+
+  GOVERNMENT USE: If you are acquiring this software on behalf of the
+  U.S. government, the Government shall have only "Restricted Rights"
+  in the software and related documentation as defined in the Federal
+  Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
+  are acquiring the software on behalf of the Department of Defense, the
+  software shall be classified as "Commercial Computer Software" and the
+  Government shall have only "Restricted Rights" as defined in Clause
+  252.227-7013 (c) (1) of DFARs.  Notwithstanding the foregoing, the
+  authors grant the U.S. Government and others acting in its behalf
+  permission to use and distribute the software in accordance with the
+  terms specified in this license.


### PR DESCRIPTION
Fixes #565; see that issue for further analysis.

Changes proposed in this pull request:

* Instead of merely mentioning the licenses of copied/forked code snippets, include the full text in LICENSE.txt. Both of these licenses require the copyright notice and the license text to be distributed in all copies. 