### PR TITLE
Replace deprecated repository_url with repository-url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,4 +197,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Re: https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0

Committed via https://github.com/asottile/all-repos