### PR TITLE
Remove unmaintained nujson from benchmark and bump to Python 3.11

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/benchmark.yml"
       - "tests/benchmark.py"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: [ubuntu-22.04]
 
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade nujson orjson simplejson
+          python -m pip install --upgrade orjson simplejson
           python -m pip install .
 
       - name: Tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,8 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - run: git fetch --prune --unshallow
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Linux 5.15.0-1037-azure x86_64 #44-Ubuntu SMP Thu Apr 20 13:19:31 UTC 2023
 ### Versions
 
 - CPython 3.11.3 (main, Apr  6 2023, 07:55:46) [GCC 11.3.0]
-- ujson        : 1.36.dev558
+- ujson        : 5.7.1.dev26
 - orjson       : 3.9.0
 - simplejson   : 3.19.1
 - json         : 2.0.9
@@ -98,31 +98,31 @@ Linux 5.15.0-1037-azure x86_64 #44-Ubuntu SMP Thu Apr 20 13:19:31 UTC 2023
 |                                                                               | ujson      | orjson     | simplejson | json       |
 |-------------------------------------------------------------------------------|-----------:|-----------:|-----------:|-----------:|
 | Array with 256 doubles                                                        |            |            |            |            |
-| encode                                                                        |     16,268 |     67,856 |      4,113 |      4,144 |
-| decode                                                                        |     20,055 |     72,031 |     10,059 |     10,158 |
+| encode                                                                        |     18,282 |     79,569 |      5,681 |      5,935 |
+| decode                                                                        |     28,765 |     93,283 |     13,844 |     13,367 |
 | Array with 256 UTF-8 strings                                                  |            |            |            |            |
-| encode                                                                        |      2,468 |     24,117 |      2,337 |      2,437 |
-| decode                                                                        |      2,472 |      2,860 |        364 |      1,393 |
+| encode                                                                        |      3,457 |     26,437 |      3,630 |      3,653 |
+| decode                                                                        |      3,576 |      4,236 |        522 |      1,978 |
 | Array with 256 strings                                                        |            |            |            |            |
-| encode                                                                        |     37,144 |    110,032 |     15,895 |     18,304 |
-| decode                                                                        |     25,211 |     59,879 |     32,200 |     32,933 |
+| encode                                                                        |     44,769 |    125,920 |     21,401 |     23,565 |
+| decode                                                                        |     28,518 |     75,043 |     41,496 |     42,221 |
 | Medium complex object                                                         |            |            |            |            |
-| encode                                                                        |      6,501 |     38,501 |      3,025 |      4,415 |
-| decode                                                                        |      9,518 |     18,114 |      5,901 |      7,286 |
+| encode                                                                        |     11,672 |     47,659 |      3,913 |      5,729 |
+| decode                                                                        |     12,522 |     23,599 |      8,007 |      9,720 |
 | Array with 256 True values                                                    |            |            |            |            |
-| encode                                                                        |     83,830 |    324,140 |     65,395 |     66,498 |
-| decode                                                                        |    162,760 |    281,594 |    118,120 |    125,927 |
+| encode                                                                        |    110,444 |    425,919 |     81,428 |     84,347 |
+| decode                                                                        |    203,430 |    318,193 |    146,867 |    156,249 |
 | Array with 256 dict{string, int} pairs                                        |            |            |            |            |
-| encode                                                                        |      9,265 |     58,508 |      2,295 |      5,504 |
-| decode                                                                        |     12,911 |     20,799 |      7,110 |      9,592 |
+| encode                                                                        |     14,170 |     72,514 |      3,050 |      7,079 |
+| decode                                                                        |     19,116 |     27,542 |      9,374 |     13,713 |
 | Dict with 256 arrays with 256 dict{string, int} pairs                         |            |            |            |            |
-| encode                                                                        |         35 |        232 |          7 |         19 |
-| decode                                                                        |         31 |         34 |         18 |         22 |
+| encode                                                                        |         55 |        282 |         11 |         26 |
+| decode                                                                        |         48 |         53 |         27 |         34 |
 | Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys |            |            |            |            |
-| encode                                                                        |         27 |            |          6 |         20 |
+| encode                                                                        |         42 |            |          8 |         27 |
 | Complex object                                                                |            |            |            |            |
-| encode                                                                        |        448 |            |        341 |        396 |
-| decode                                                                        |        468 |        591 |        162 |        266 |
+| encode                                                                        |        462 |            |        397 |        444 |
+| decode                                                                        |        480 |        618 |        177 |        310 |
 
 Above metrics are in call/sec, larger is better.
 

--- a/README.md
+++ b/README.md
@@ -85,44 +85,44 @@ specified below each.
 
 ### Test machine
 
-Linux 5.15.0-1038-azure x86_64 #45-Ubuntu SMP Mon Apr 24 15:40:42 UTC 2023
+Linux 5.15.0-1037-azure x86_64 #44-Ubuntu SMP Thu Apr 20 13:19:31 UTC 2023
 
 ### Versions
 
 - CPython 3.11.3 (main, Apr  6 2023, 07:55:46) [GCC 11.3.0]
-- ujson        : 0.1.dev1
-- orjson       : 3.8.14
+- ujson        : 1.36.dev558
+- orjson       : 3.9.0
 - simplejson   : 3.19.1
 - json         : 2.0.9
 
 |                                                                               | ujson      | orjson     | simplejson | json       |
 |-------------------------------------------------------------------------------|-----------:|-----------:|-----------:|-----------:|
 | Array with 256 doubles                                                        |            |            |            |            |
-| encode                                                                        |     12,600 |     66,051 |      4,126 |      4,264 |
-| decode                                                                        |     19,852 |     64,581 |     10,330 |     10,378 |
+| encode                                                                        |     16,268 |     67,856 |      4,113 |      4,144 |
+| decode                                                                        |     20,055 |     72,031 |     10,059 |     10,158 |
 | Array with 256 UTF-8 strings                                                  |            |            |            |            |
-| encode                                                                        |      2,355 |     24,212 |      2,086 |      2,134 |
-| decode                                                                        |      1,898 |      2,878 |        342 |      1,207 |
+| encode                                                                        |      2,468 |     24,117 |      2,337 |      2,437 |
+| decode                                                                        |      2,472 |      2,860 |        364 |      1,393 |
 | Array with 256 strings                                                        |            |            |            |            |
-| encode                                                                        |     35,411 |    108,693 |     12,733 |     17,228 |
-| decode                                                                        |     23,124 |     60,845 |     30,166 |     27,527 |
+| encode                                                                        |     37,144 |    110,032 |     15,895 |     18,304 |
+| decode                                                                        |     25,211 |     59,879 |     32,200 |     32,933 |
 | Medium complex object                                                         |            |            |            |            |
-| encode                                                                        |      8,713 |     39,394 |      3,331 |      4,573 |
-| decode                                                                        |      9,658 |     17,423 |      6,327 |      7,553 |
+| encode                                                                        |      6,501 |     38,501 |      3,025 |      4,415 |
+| decode                                                                        |      9,518 |     18,114 |      5,901 |      7,286 |
 | Array with 256 True values                                                    |            |            |            |            |
-| encode                                                                        |     81,437 |    344,365 |     63,885 |     59,843 |
-| decode                                                                        |    157,638 |    270,217 |    120,104 |    121,518 |
+| encode                                                                        |     83,830 |    324,140 |     65,395 |     66,498 |
+| decode                                                                        |    162,760 |    281,594 |    118,120 |    125,927 |
 | Array with 256 dict{string, int} pairs                                        |            |            |            |            |
-| encode                                                                        |     10,942 |     56,421 |      2,527 |      5,743 |
-| decode                                                                        |     13,976 |     20,372 |      7,828 |     10,215 |
+| encode                                                                        |      9,265 |     58,508 |      2,295 |      5,504 |
+| decode                                                                        |     12,911 |     20,799 |      7,110 |      9,592 |
 | Dict with 256 arrays with 256 dict{string, int} pairs                         |            |            |            |            |
-| encode                                                                        |         42 |        221 |          8 |         21 |
-| decode                                                                        |         35 |         43 |         22 |         27 |
+| encode                                                                        |         35 |        232 |          7 |         19 |
+| decode                                                                        |         31 |         34 |         18 |         22 |
 | Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys |            |            |            |            |
-| encode                                                                        |         33 |            |          7 |         22 |
+| encode                                                                        |         27 |            |          6 |         20 |
 | Complex object                                                                |            |            |            |            |
-| encode                                                                        |        395 |            |        341 |        376 |
-| decode                                                                        |        401 |        530 |        150 |        249 |
+| encode                                                                        |        448 |            |        341 |        396 |
+| decode                                                                        |        468 |        591 |        162 |        266 |
 
 Above metrics are in call/sec, larger is better.
 

--- a/README.md
+++ b/README.md
@@ -85,44 +85,46 @@ specified below each.
 
 ### Test machine
 
-Linux 5.0.0-1032-azure x86_64 #34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020
+Linux 5.15.0-1038-azure x86_64 #45-Ubuntu SMP Mon Apr 24 15:40:42 UTC 2023
 
 ### Versions
 
-- CPython 3.8.2 (default, Feb 28 2020, 14:28:43) [GCC 7.4.0]
-- nujson    : 1.35.2
-- orjson    : 2.6.1
-- simplejson: 3.17.0
-- ujson     : 2.0.2
+- CPython 3.11.3 (main, Apr  6 2023, 07:55:46) [GCC 11.3.0]
+- ujson        : 0.1.dev1
+- orjson       : 3.8.14
+- simplejson   : 3.19.1
+- json         : 2.0.9
 
-|                                                                               | ujson      | nujson     | orjson     | simplejson | json       |
-|-------------------------------------------------------------------------------|-----------:|-----------:|-----------:|-----------:|-----------:|
-| Array with 256 doubles                                                        |            |            |            |            |            |
-| encode                                                                        |     22,082 |      4,282 |     76,975 |      5,328 |      5,436 |
-| decode                                                                        |     24,127 |     34,349 |     29,059 |     14,174 |     13,822 |
-| Array with 256 UTF-8 strings                                                  |            |            |            |            |            |
-| encode                                                                        |      3,557 |      2,528 |     24,300 |      3,061 |      2,068 |
-| decode                                                                        |      2,030 |      2,490 |        931 |        406 |        358 |
-| Array with 256 strings                                                        |            |            |            |            |            |
-| encode                                                                        |     39,041 |     31,769 |     76,403 |     16,615 |     16,910 |
-| decode                                                                        |     25,185 |     24,287 |     34,437 |     32,388 |     27,999 |
-| Medium complex object                                                         |            |            |            |            |            |
-| encode                                                                        |     10,382 |     11,427 |     32,995 |      3,959 |      5,275 |
-| decode                                                                        |      9,785 |      9,796 |     11,515 |      5,898 |      7,200 |
-| Array with 256 True values                                                    |            |            |            |            |            |
-| encode                                                                        |    114,341 |    101,039 |    344,256 |     62,382 |     72,872 |
-| decode                                                                        |    149,367 |    151,615 |    181,123 |    114,597 |    130,392 |
-| Array with 256 dict{string, int} pairs                                        |            |            |            |            |            |
-| encode                                                                        |     13,715 |     14,420 |     51,942 |      3,271 |      6,584 |
-| decode                                                                        |     12,670 |     11,788 |     12,176 |      6,743 |      8,278 |
-| Dict with 256 arrays with 256 dict{string, int} pairs                         |            |            |            |            |            |
-| encode                                                                        |         50 |         54 |        216 |         10 |         23 |
-| decode                                                                        |         32 |         32 |         30 |         20 |         23 |
-| Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys |            |            |            |            |            |
-| encode                                                                        |         46 |         41 |            |          8 |         24 |
-| Complex object                                                                |            |            |            |            |            |
-| encode                                                                        |        533 |        582 |            |        408 |        431 |
-| decode                                                                        |        466 |        454 |            |        154 |        164 |
+|                                                                               | ujson      | orjson     | simplejson | json       |
+|-------------------------------------------------------------------------------|-----------:|-----------:|-----------:|-----------:|
+| Array with 256 doubles                                                        |            |            |            |            |
+| encode                                                                        |     12,600 |     66,051 |      4,126 |      4,264 |
+| decode                                                                        |     19,852 |     64,581 |     10,330 |     10,378 |
+| Array with 256 UTF-8 strings                                                  |            |            |            |            |
+| encode                                                                        |      2,355 |     24,212 |      2,086 |      2,134 |
+| decode                                                                        |      1,898 |      2,878 |        342 |      1,207 |
+| Array with 256 strings                                                        |            |            |            |            |
+| encode                                                                        |     35,411 |    108,693 |     12,733 |     17,228 |
+| decode                                                                        |     23,124 |     60,845 |     30,166 |     27,527 |
+| Medium complex object                                                         |            |            |            |            |
+| encode                                                                        |      8,713 |     39,394 |      3,331 |      4,573 |
+| decode                                                                        |      9,658 |     17,423 |      6,327 |      7,553 |
+| Array with 256 True values                                                    |            |            |            |            |
+| encode                                                                        |     81,437 |    344,365 |     63,885 |     59,843 |
+| decode                                                                        |    157,638 |    270,217 |    120,104 |    121,518 |
+| Array with 256 dict{string, int} pairs                                        |            |            |            |            |
+| encode                                                                        |     10,942 |     56,421 |      2,527 |      5,743 |
+| decode                                                                        |     13,976 |     20,372 |      7,828 |     10,215 |
+| Dict with 256 arrays with 256 dict{string, int} pairs                         |            |            |            |            |
+| encode                                                                        |         42 |        221 |          8 |         21 |
+| decode                                                                        |         35 |         43 |         22 |         27 |
+| Dict with 256 arrays with 256 dict{string, int} pairs, outputting sorted keys |            |            |            |            |
+| encode                                                                        |         33 |            |          7 |         22 |
+| Complex object                                                                |            |            |            |            |
+| encode                                                                        |        395 |            |        341 |        376 |
+| decode                                                                        |        401 |        530 |        150 |        249 |
+
+Above metrics are in call/sec, larger is better.
 
 ## Build options
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -11,7 +11,6 @@ import ujson
 
 # Will be set by "main" if user requests them
 simplejson = None
-nujson = None
 orjson = None
 
 USER = {
@@ -160,11 +159,6 @@ def dumps_with_json():
     json.dumps(test_object)
 
 
-@register_benchmark("nujson", _testname)
-def dumps_with_nujson():
-    nujson.dumps(test_object)
-
-
 @register_benchmark("orjson", _testname)
 def dumps_with_orjson():
     orjson.dumps(test_object)
@@ -197,11 +191,6 @@ def dumps_sorted_with_simplejson():
     simplejson.dumps(test_object, sort_keys=True)
 
 
-@register_benchmark("nujson", _testname)
-def dumps_sorted_with_nujson():
-    nujson.dumps(test_object, sort_keys=True)
-
-
 @register_benchmark("orjson", _testname)
 def dumps_sorted_with_orjson():
     orjson.dumps(test_object, sort_keys=True)
@@ -222,11 +211,6 @@ _testname = "loads"
 @register_benchmark("json", _testname)
 def loads_with_json():
     json.loads(decode_data)
-
-
-@register_benchmark("nujson", _testname)
-def loads_with_nujson():
-    nujson.loads(decode_data)
 
 
 @register_benchmark("orjson", _testname)
@@ -437,7 +421,6 @@ def main():
 
     known_libraries = [
         "ujson",
-        "nujson",
         "orjson",
         "simplejson",
         "json",


### PR DESCRIPTION
The benchmark CI job has been failing for a couple of months:

https://github.com/ultrajson/ultrajson/actions/workflows/benchmark.yml

Because it's failing to build the wheel for nujson:

<details>
<summary>Details</summary>

```
Building wheels for collected packages: nujson
  Building wheel for nujson (pyproject.toml): started
  Building wheel for nujson (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Building wheel for nujson (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      Warning: 'classifiers' should be a list, got type 'filter'
      running bdist_wheel
      running build
      running build_ext
      Traceback (most recent call last):
Failed to build nujson
        File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 416, in build_wheel
          return self._build_with_temp_dir(['bdist_wheel'], '.whl',
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 401, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 487, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 77, in <module>
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 107, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1244, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/wheel/bdist_wheel.py", line 3[43](https://github.com/ultrajson/ultrajson/actions/runs/5141046608/jobs/9253110620#step:4:44), in run
          self.run_command("build")
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 12[44](https://github.com/ultrajson/ultrajson/actions/runs/5141046608/jobs/9253110620#step:4:45), in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/build.py", line 131, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1244, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-fpxckxlz/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "<string>", line [68](https://github.com/ultrajson/ultrajson/actions/runs/5141046608/jobs/9253110620#step:4:69), in run
      ModuleNotFoundError: No module named 'numpy'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nujson
ERROR: Could not build wheels for nujson, which is required to install pyproject.toml-based projects
```

</details>

However, https://pypi.org/project/nujson/ hasn't had any releases since December 2019 and https://github.com/caiyunapp/ultrajson has been archived since August 2022.

Let's just remove it.

I updated the benchmark results on the README from a CI run: https://github.com/hugovk/ultrajson/actions/runs/5145083552/jobs/9262222063