### PR TITLE
Build wheel for Python 3.12 beta

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,6 @@ jobs:
           cache: pip
           cache-dependency-path: ".github/workflows/deploy.yml"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U twine
-
       # https://github.com/pypa/cibuildwheel
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
@@ -64,20 +60,22 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_password }}
-        run: twine upload --skip-existing dist/*.whl
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          skip-existing: true
 
       - name: Publish package to TestPyPI
         if: |
           github.repository == 'ultrajson/ultrajson' &&
           github.ref == 'refs/heads/main'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
-        run: |
-          twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*.whl
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   build-QEMU-emulated-wheels:
     runs-on: ubuntu-latest
@@ -105,10 +103,6 @@ jobs:
           python-version: "3.x"
           cache: pip
           cache-dependency-path: ".github/workflows/deploy.yml"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install -U twine
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
@@ -144,20 +138,22 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_password }}
-        run: twine upload --skip-existing dist/*.whl
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          skip-existing: true
 
       - name: Publish package to TestPyPI
         if: |
           github.repository == 'ultrajson/ultrajson' &&
           github.ref == 'refs/heads/main'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
-        run: |
-          twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*.whl
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   build-sdist:
     runs-on: ubuntu-latest
@@ -178,7 +174,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U build twine wheel
+          python -m pip install -U build twine
 
       - name: Build package
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,8 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           # Build only on Linux architectures that don't need qemu emulation.
           CIBW_ARCHS_LINUX: "x86_64 i686"
+          # Include latest Python beta.
+          CIBW_PRERELEASE_PYTHONS: True
           # Run the test suite after each build.
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: pytest {package}/tests
@@ -91,6 +93,7 @@ jobs:
           - cp39
           - cp310
           - cp311
+          - cp312
 
     steps:
       - uses: actions/checkout@v3
@@ -127,6 +130,8 @@ jobs:
           CIBW_ARCHS_LINUX: "aarch64"
           # Likewise, select only one Python version per job to speed this up.
           CIBW_BUILD: "${{ matrix.python-version }}-*"
+          # Include latest Python beta.
+          CIBW_PRERELEASE_PYTHONS: True
           # Run the test suite after each build.
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,11 +39,11 @@ repos:
       - id: trailing-whitespace
         exclude: "^.github/.*_TEMPLATE.md"
 
-# Disabled due to asottile/setup-cfg-fmt#73. Re-enable once that issue is fixed.
-#  - repo: https://github.com/asottile/setup-cfg-fmt
-#    rev: v1.20.1
-#    hooks:
-#      - id: setup-cfg-fmt
 
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.3.0
+    hooks:
+      - id: setup-cfg-fmt
+        args: [--include-version-classifiers, --max-py-version=3.12]
 ci:
   autoupdate_schedule: quarterly

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 download_url = https://github.com/ultrajson/ultrajson
 project_urls =
     Source=https://github.com/ultrajson/ultrajson


### PR DESCRIPTION
We've been testing Python 3.12 since alpha (https://github.com/ultrajson/ultrajson/pull/571), and it's now in beta.

The [3.12 release manager said](https://discuss.python.org/t/python-3-12-beta-1-and-feature-freeze-is-here/26982?u=hugovk):

> We **strongly encourage** maintainers of third-party Python projects to test with 3.12 during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature complete entering the beta phase, it is possible that features may be modified or, in rare cases, deleted up until the start of the release candidate phase (Monday, 2023-07-31). Our goal is to have no ABI changes after beta 4 and as few code changes as possible after 3.12.0rc1, the first release candidate. To achieve that, it will be **extremely important** to get as much exposure for 3.12 as possible during the beta phase.


I think it would be a good time to also build wheels for 3.12. This will help others, who depend on UltraJSON, to more easily test and prepare their libraries.

It is possible for ABI changes to occur, but these wheels should also be considered beta, and we can easily put out new releases for new beta (or add a build number and upload to the same release).

---

We're using https://github.com/pypa/gh-action-pypi-publish directly to upload sdists, but twine for the wheels. I've switched the wheels to https://github.com/pypa/gh-action-pypi-publish as well, because I'd like to improve security by switching over to using a "trusted publisher" that makes use of short-lived tokens instead of a persistent one (which lives on my personal account) and is saved in repo secrets.

More info:

* https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
* https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

But to configure this on PyPI, I'd need "owner" access rather than "maintainer".

@cgbystrom Please could you give me owner access at https://pypi.org/manage/project/ujson/collaboration/?
