### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,10 +83,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - pp37
           - pp38
           - pp39
-          - cp37
           - cp38
           - cp39
           - cp310

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [ubuntu-latest]
         include:
           - { python-version: "pypy-3.8", os: windows-latest }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-        args: [--target-version=py37]
+        args: [--target-version=py38]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -39,11 +39,11 @@ repos:
       - id: trailing-whitespace
         exclude: "^.github/.*_TEMPLATE.md"
 
-# Disabled due to asottile/setup-cfg-fmt#73. Re-enable once that issue is fixed.
-#  - repo: https://github.com/asottile/setup-cfg-fmt
-#    rev: v1.20.1
-#    hooks:
-#      - id: setup-cfg-fmt
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.3.0
+    hooks:
+      - id: setup-cfg-fmt
+        args: [--include-version-classifiers]
 
 ci:
   autoupdate_schedule: quarterly

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
 UltraJSON is an ultra fast JSON encoder and decoder written in pure C with bindings for
-Python 3.7+.
+Python 3.8+.
 
 Install with pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 
 [tool.black]
-target_version = ["py37"]
+target_version = ["py38"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Programming Language :: C
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -24,7 +23,7 @@ project_urls =
     Source=https://github.com/ultrajson/ultrajson
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools-scm
 


### PR DESCRIPTION
Python 3.7 is EOL this month:

<img width="751" alt="image" src="https://github.com/ultrajson/ultrajson/assets/1324225/7f2736b1-3aef-48f6-b863-4787c754147d">

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0537/

Let's drop it, it'll save us [14 wheels](https://pypi.org/project/ujson/5.7.0/#files) (and we're adding more for 3.12 in https://github.com/ultrajson/ultrajson/pull/594 :)

I don't mind if wait until 2023-06-27, but we're probably close enough.
