### PR TITLE
CI deploy: Upload all wheels from a single, final job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,25 +58,6 @@ jobs:
           name: wheels
           path: dist/*.whl
 
-      - name: Publish package to PyPI
-        if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          skip-existing: true
-
-      - name: Publish package to TestPyPI
-        if: |
-          github.repository == 'ultrajson/ultrajson' &&
-          github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.test_pypi_password }}
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
   build-QEMU-emulated-wheels:
     runs-on: ubuntu-latest
     strategy:
@@ -134,26 +115,7 @@ jobs:
           name: wheels
           path: dist/*.whl
 
-      - name: Publish package to PyPI
-        if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          skip-existing: true
-
-      - name: Publish package to TestPyPI
-        if: |
-          github.repository == 'ultrajson/ultrajson' &&
-          github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.test_pypi_password }}
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
-  build-sdist:
+  build-sdist-and-upload:
     runs-on: ubuntu-latest
     needs: ['build-native-wheels', 'build-QEMU-emulated-wheels']
 
@@ -173,6 +135,12 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U build twine
+
+      - name: Download wheels from build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist/
 
       - name: Build package
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wheels
-          path: dist/
+          path: dist-wheels/
 
       - name: Build package
         run: |
@@ -148,15 +148,35 @@ jobs:
           python setup.py --version
           python -m build --sdist
           twine check --strict dist/*
+          twine check --strict dist-wheels/*
 
-      - name: Publish package to PyPI
+      - name: Publish wheels to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages-dir: dist-wheels/
+
+      - name: Publish sdist to PyPI
         if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
 
-      - name: Publish package to TestPyPI
+      - name: Publish wheels to TestPyPI
+        if: |
+          github.repository == 'ultrajson/ultrajson' &&
+          github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist-wheels/
+
+      - name: Publish sdist to TestPyPI
         if: |
           github.repository == 'ultrajson/ultrajson' &&
           github.ref == 'refs/heads/main'


### PR DESCRIPTION
Follow on from https://github.com/ultrajson/ultrajson/pull/594#issuecomment-1577062696.

We can't use https://github.com/pypa/gh-action-pypi-publish to upload from macOS or Windows, so download all wheels in the final job and upload them all at the same time as the sdist.
