### PR TITLE
CI: Replace pypy3.8 with pypy3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy-3.10", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         include:
-          - { python-version: "pypy-3.8", os: windows-latest }
-          - { python-version: "pypy-3.8", os: macos-latest }
+          - { python-version: "pypy-3.10", os: windows-latest }
+          - { python-version: "pypy-3.10", os: macos-latest }
           - { python-version: "3.10", os: windows-latest }
           - { python-version: "3.10", os: macos-latest }
           - { python-version: "3.11", os: windows-latest }
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: "setup.py"
 


### PR DESCRIPTION
PyPy v7.3.12 has been released, adding 3.10 and dropping 3.8:

* https://www.pypy.org/posts/2023/06/pypy-v7312-release.html

cibuildwheel will be adding support in a week or so, at the same time when they drop 3.7:

* https://github.com/pypa/cibuildwheel/pull/1525
* https://github.com/pypa/cibuildwheel/pull/1526#pullrequestreview-1484875887

We can also use `allow-prereleases: true` to put `3.12` in the matrix instead of `3.12-dev`:

* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases