### PR TITLE
Replace PyPy3.8 wheel with PyPy3.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,8 +64,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - pp38
           - pp39
+          - pp310
           - cp38
           - cp39
           - cp310


### PR DESCRIPTION
Following https://github.com/ultrajson/ultrajson/pull/601, cibuildwheel adds support for building PyPy 3.10 wheels.

The latest PyPy release supports PyPy3.9 and PyPy3.10, dropping PyPy3.8:

* https://www.pypy.org/posts/2023/06/pypy-v7312-release.html 

To match, let's build wheels for the same versions.