### PR TITLE
Deploy to PyPI using trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,9 @@ jobs:
   build-sdist-and-upload:
     runs-on: ubuntu-latest
     needs: ['build-native-wheels', 'build-QEMU-emulated-wheels']
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -154,16 +157,11 @@ jobs:
         if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
           packages-dir: dist-wheels/
 
       - name: Publish sdist to PyPI
         if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
 
       - name: Publish wheels to TestPyPI
         if: |
@@ -171,8 +169,6 @@ jobs:
           github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.test_pypi_password }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist-wheels/
 
@@ -182,6 +178,4 @@ jobs:
           github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.test_pypi_password }}
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Follow on from https://github.com/ultrajson/ultrajson/pull/594:

> We're using https://github.com/pypa/gh-action-pypi-publish directly to upload sdists, but twine for the wheels. I've switched the wheels to https://github.com/pypa/gh-action-pypi-publish as well, because I'd like to improve security by switching over to using a "trusted publisher" that makes use of short-lived tokens instead of a persistent one (which lives on my personal account) and is saved in repo secrets.
> 
> More info:
> 
> * https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
> * https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
> 
> But to configure this on PyPI, I'd need "owner" access rather than "maintainer".

I emailed Jonas Tarnstrom, one of the former maintainers, and he's given me access so I've now set up trusted publishing for this project at https://pypi.org/manage/project/ujson/settings/publishing/:

<img width="584" alt="image" src="https://github.com/ultrajson/ultrajson/assets/1324225/e851f11e-d84d-4a7e-84d8-762a31c5748e">

We should have the same thing on TestPyPI too: @segfault, I think you initially set up https://test.pypi.org/project/ujson/? Please could you give me owner access there too? Thanks!

# TODO

* [x] @segfault to make `hugovk` owner at https://test.pypi.org/project/ujson/
* [x] Set up trusted publishing at https://test.pypi.org/manage/project/ujson/settings/publishing/
* [x] Merge, check deploys to TestPyPI
* [ ] Release, check deploys to prod PyPI
* [x] Delete long-lived `TEST_PYPI_PASSWORD` from https://github.com/ultrajson/ultrajson/settings/secrets/actions
* [ ] Delete long-lived `PYPI_PASSWORD` from https://github.com/ultrajson/ultrajson/settings/secrets/actions
* [x] Delete long-lived `ujson-gha` token from my account at https://test.pypi.org/manage/account/
* [ ] Delete long-lived `ujson-gha` token from my account at https://pypi.org/manage/account/
