### PR TITLE
Fix typos found by codespell

### DIFF
--- a/deps/double-conversion/double-conversion/double-to-string.h
+++ b/deps/double-conversion/double-conversion/double-to-string.h
@@ -325,7 +325,7 @@ class DoubleToStringConverter {
   // except for the following cases:
   //   - the input value is special and no infinity_symbol or nan_symbol has
   //     been provided to the constructor,
-  //   - precision < kMinPericisionDigits
+  //   - precision < kMinPrecisionDigits
   //   - precision > kMaxPrecisionDigits
   //
   // The last condition implies that the result never contains more than

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -201,12 +201,12 @@ typedef struct __JSONObjectEncoder
 
   /*
   Retrieve next object in an iteration. Should return 0 to indicate iteration has reached end or 1 if there are more items.
-  Implementor is responsible for keeping state of the iteration. Use ti->prv fields for this
+  Implementer is responsible for keeping state of the iteration. Use ti->prv fields for this
   */
   JSPFN_ITERNEXT iterNext;
 
   /*
-  Ends the iteration of an iteratable object.
+  Ends the iteration of an iterable object.
   Any iteration state stored in ti->prv can be freed here
   */
   JSPFN_ITEREND iterEnd;
@@ -284,7 +284,7 @@ typedef struct __JSONObjectEncoder
   void *d2s;
 
   /*
-  Set to an error message if error occured */
+  Set to an error message if error occurred */
   const char *errorMsg;
   JSOBJ errorObj;
 


### PR DESCRIPTION
I am happy to revert `Implementor` → `Implementer` if you want me too.

The reason why codespell flags `implementor` as a misspelling is:
* Both `implementer` and `implementor` are [missing from OED](https://www.oed.com/search/dictionary/?q=implementer).
* `implementer` is 10× more common than `implementor` in contemporary English, both US and UK ([Google Ngram viewer](https://books.google.com/ngrams/graph?content=implementer%2Cimplementor&year_start=1800&year_end=2019&corpus=en-2019)).
* The open-source reference for spell checking, [SCOWL (and Friends)](http://wordlist.aspell.net/), does have [`implementer`](http://app.aspell.net/lookup?dict=en_GB-large;words=implementer), but not [`implementor`](http://app.aspell.net/lookup?dict=en_GB-large;words=implementor).