### PR TITLE
README: replace expired esn.me with example.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ save space:
 Controls whether forward slashes (`/`) are escaped. Default is `True`:
 
 ```pycon
->>> ujson.dumps("http://esn.me")
-'"http:\\/\\/esn.me"'
->>> ujson.dumps("http://esn.me", escape_forward_slashes=False)
-'"http://esn.me"'
+>>> ujson.dumps("https://example.com")
+'"https:\\/\\/example.com"'
+>>> ujson.dumps("https://example.com", escape_forward_slashes=False)
+'"https://example.com"'
 ```
 
 #### indent


### PR DESCRIPTION
Update the example in the README.

There's nothing at http://esn.me/ and it's better to use https://example.com (or other [IANA reserved domains](https://www.iana.org/domains/reserved)).

I have seen documentation using non-example.com domains which had lapsed, been re-registered and infected with malware!