### PR TITLE
Speed-up and cleanup objToJSON

### DIFF
--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -576,6 +576,13 @@ def test_sort_keys():
     assert sorted_keys == '{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1}'
 
 
+def test_sort_keys_unordered():
+    data = {"a": 1, 1: 2, None: 3}
+    assert ujson.dumps(data) == '{"a":1,"1":2,"null":3}'
+    with pytest.raises(TypeError):
+        ujson.dumps(data, sort_keys=True)
+
+
 @pytest.mark.parametrize(
     "test_input",
     [


### PR DESCRIPTION
* Use PyDict_Next() to iterate over dicts.
* Use macros to access lists, tuples, bytes.
* Avoid calling PyErr_Occurred() if not necessary.
* Fix a memory leak when encoding very large ints.
* Delete dead and duplicate code.

Also,

* Raise TypeError if toDict() returns a non-dict instead of silently converting it to null.
