### PR TITLE
Remove unused docker/setup-buildx-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,10 +87,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       # https://github.com/pypa/cibuildwheel
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Test
         run: |
           docker run -v "$PWD:/io" --platform=linux/${{ matrix.architecture }} python:alpine ash -e -c '


### PR DESCRIPTION
https://github.com/docker/setup-buildx-action is ~needed for the tests in `test.yml`, but not for building the wheels with cibuildwheel~ not needed.