### PR TITLE
Support Python's Negative Exponent Padding Idiosyncrasy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ Controls whether indentation ("pretty output") is enabled. Default is `0` (disab
 }
 ```
 
+#### zero_pad_negative_9_to_5_exponent
+
+If true, adds a single `0` padding to the exponent in scientific notation if it
+is between `-9` and `-5` both inclusive, which replicates the Python standard
+library's `json` behavior.  Default is `False`:
+
+```pycon
+>>> ujson.dumps([1e-10, 1e-9, 1e-5, 1e-4])
+'[1e-10,1e-9,1e-5,0.0001]'
+>>> ujson.dumps([1e-10, 1e-9, 1e-5, 1e-4], zero_pad_negative_9_to_5_exponent=True)
+'[1e-10,1e-09,1e-05,0.0001]'
+```
+
 ## Benchmarks
 
 *UltraJSON* calls/sec compared to other popular JSON parsers with performance gain

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -12,12 +12,13 @@ namespace double_conversion
                         int decimal_in_shortest_low,
                         int decimal_in_shortest_high,
                         int max_leading_padding_zeroes_in_precision_mode,
-                        int max_trailing_padding_zeroes_in_precision_mode)
+                        int max_trailing_padding_zeroes_in_precision_mode,
+                        int min_exponent_width)
     {
         *d2s = new DoubleToStringConverter(flags, infinity_symbol, nan_symbol,
                                         exponent_character, decimal_in_shortest_low,
                                         decimal_in_shortest_high, max_leading_padding_zeroes_in_precision_mode,
-                                        max_trailing_padding_zeroes_in_precision_mode);
+                                        max_trailing_padding_zeroes_in_precision_mode, min_exponent_width);
     }
 
     int dconv_d2s(void *d2s, double value, char* buf, int buflen, int* strlength)

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -269,6 +269,12 @@ typedef struct __JSONObjectEncoder
   int rejectBytes;
 
   /*
+  If true, adds a single 0 padding to the exponent in scientific notation if it
+  is between -9 and -5 both inclusive, which replicates the Python standard
+  library's JSON behavior, e.g. 1e-5 will become 1e-05. */
+  int zeroPadNegative9to5Exponent;
+
+  /*
   Configuration for item and key separators, e.g. "," and ":" for a compact representation or ", " and ": " to match the Python standard library's defaults. */
   size_t itemSeparatorLength;
   const char *itemSeparatorChars;
@@ -382,7 +388,8 @@ void dconv_d2s_init(void **d2s,
                     int decimal_in_shortest_low,
                     int decimal_in_shortest_high,
                     int max_leading_padding_zeroes_in_precision_mode,
-                    int max_trailing_padding_zeroes_in_precision_mode);
+                    int max_trailing_padding_zeroes_in_precision_mode,
+                    int min_exponent_width);
 int dconv_d2s(void *d2s, double value, char* buf, int buflen, int* strlength);
 void dconv_d2s_free(void **d2s);
 

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -59,7 +59,8 @@ PyObject* JSONDecodeError;
     "Set encode_html_chars=True to encode < > & as unicode escape sequences. "\
     "Set escape_forward_slashes=False to prevent escaping / characters." \
     "Set allow_nan=False to raise an exception when NaN or Infinity would be serialized." \
-    "Set reject_bytes=True to raise TypeError on bytes."
+    "Set reject_bytes=True to raise TypeError on bytes." \
+    "Set zero_pad_negative_9_to_5_exponent=True to add 0-pad for exponents -9 to -5."
 
 static PyMethodDef ujsonMethods[] = {
   {"encode", (PyCFunction) objToJSON, METH_VARARGS | METH_KEYWORDS, "Converts arbitrary object recursively into JSON. " ENCODER_HELP_TEXT},

--- a/tests/fuzz.py
+++ b/tests/fuzz.py
@@ -134,6 +134,13 @@ parser.add_argument(
     "May be 0 or 1 or 0,1 to test both.",
 )
 parser.add_argument(
+    "--zero_pad_negative_9_to_5_exponent",
+    default=(0, 1),
+    action=ListOption,
+    help="Sets the zero_pad_negative_9_to_5_exponent option to ujson.dumps(). "
+    "May be 0 or 1 or 0,1 to test both.",
+)
+parser.add_argument(
     "--dump-python",
     action="store_true",
     help="Print the randomly generated object as a Python literal and exit.",

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -84,10 +84,17 @@ def test_double_long_decimal_issue():
     assert sut == decoded
 
 
-# NOTE: can't match exponents -9 to -5; Python 0-pads
+# NOTE: The default behaviour can't match exponents -9 to -5; Python 0-pads
 @pytest.mark.parametrize("val", [1e-10, 1e-4, 1e10, 1e15, 1e16, 1e30])
 def test_encode_float_string_rep(val):
     assert ujson.dumps(val) == json.dumps(val)
+
+
+@pytest.mark.parametrize(
+    "val", [1e-10, 1e-9, 1e-8, 1e-6, 1e-5, 1e-4, 1e10, 1e15, 1e16, 1e30]
+)
+def test_encode_float_string_replicate_python(val):
+    assert ujson.dumps(val, zero_pad_negative_9_to_5_exponent=True) == json.dumps(val)
 
 
 def test_encode_decode_long_decimal():


### PR DESCRIPTION
Changes proposed in this pull request:

* Introduce a new option called `zero_pad_negative_9_to_5_exponent` which if enabled replicates the `0`-padding behaviour of the `json` module in Python's standard library.  That is, if the exponent is between `-9` to `-5` (both inclusive), `json` pads the exponent with a leading `0`, e.g. `1e-5` becomes `1e-05`.  This compatibility option is set to `False` by default, which means it is fully backward compatible.
