### PR TITLE
library lifetime for dconv convertor

### DIFF
--- a/deps/double-conversion/double-conversion/double-to-string.h
+++ b/deps/double-conversion/double-conversion/double-to-string.h
@@ -403,7 +403,6 @@ class DoubleToStringConverter {
                             int* length,
                             int* point);
 
- private:
   // Implementation for ToShortest and ToShortestSingle.
   bool ToShortestIeeeNumber(double value,
                             StringBuilder* result_builder,
@@ -428,8 +427,8 @@ class DoubleToStringConverter {
                                    StringBuilder* result_builder) const;
 
   const int flags_;
-  const char* const infinity_symbol_;
-  const char* const nan_symbol_;
+  const char* infinity_symbol_;
+  const char* nan_symbol_;
   const char exponent_character_;
   const int decimal_in_shortest_low_;
   const int decimal_in_shortest_high_;

--- a/deps/double-conversion/double-conversion/double-to-string.h
+++ b/deps/double-conversion/double-conversion/double-to-string.h
@@ -403,6 +403,7 @@ class DoubleToStringConverter {
                             int* length,
                             int* point);
 
+private:
   // Implementation for ToShortest and ToShortestSingle.
   bool ToShortestIeeeNumber(double value,
                             StringBuilder* result_builder,
@@ -427,8 +428,8 @@ class DoubleToStringConverter {
                                    StringBuilder* result_builder) const;
 
   const int flags_;
-  const char* infinity_symbol_;
-  const char* nan_symbol_;
+  const char* const infinity_symbol_;
+  const char* const nan_symbol_;
   const char exponent_character_;
   const int decimal_in_shortest_low_;
   const int decimal_in_shortest_high_;

--- a/deps/double-conversion/double-conversion/double-to-string.h
+++ b/deps/double-conversion/double-conversion/double-to-string.h
@@ -403,7 +403,7 @@ class DoubleToStringConverter {
                             int* length,
                             int* point);
 
-private:
+ private:
   // Implementation for ToShortest and ToShortestSingle.
   bool ToShortestIeeeNumber(double value,
                             StringBuilder* result_builder,

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -28,11 +28,20 @@ namespace double_conversion
   {
     int dconv_d2s(double value, char* buf, int buflen, int* strlength, int allow_nan)
     {
-        static DoubleToStringConverter d2s(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
-                 "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
+    DoubleToStringConverter* d2s;
+		if(allow_nan){
+      static DoubleToStringConverter d2s_w_nan(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
+                    "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
+      d2s = &d2s_w_nan;
+    }else{
+      static DoubleToStringConverter d2s_wo_nan(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
+                 NULL, NULL, 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
+      d2s = &d2s_wo_nan;
+    }
+
+		
         StringBuilder sb(buf, buflen);
-        int success =  static_cast<int>(d2s.ToShortest(value, &sb));
-        success = success && (!allow_nan || ((strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0 && strcmp(buf, "-Infinity") != 0)));
+        int success =  static_cast<int>(d2s->ToShortest(value, &sb));
         *strlength = success ? sb.position() : -1;
         return success;
     }

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -39,7 +39,7 @@ namespace double_conversion
       d2s = &d2s_wo_nan;
     }
 
-		
+
         StringBuilder sb(buf, buflen);
         int success =  static_cast<int>(d2s->ToShortest(value, &sb));
         *strlength = success ? sb.position() : -1;

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -28,7 +28,7 @@ namespace double_conversion
   {
     int dconv_d2s(double value, char* buf, int buflen, int* strlength, int allow_nan)
     {
-        static auto d2s = DoubleToStringConverter(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
+        static DoubleToStringConverter d2s(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
                  "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
         StringBuilder sb(buf, buflen);
         int success =  static_cast<int>(d2s.ToShortest(value, &sb));
@@ -39,7 +39,7 @@ namespace double_conversion
 
     double dconv_s2d(const char* buffer, int length, int* processed_characters_count)
     {
-        static auto s2d = StringToDoubleConverter(DCONV_S2D_ALLOW_TRAILING_JUNK, 0.0, 0.0, "Infinity", "NaN");
+        static StringToDoubleConverter s2d(DCONV_S2D_ALLOW_TRAILING_JUNK, 0.0, 0.0, "Infinity", "NaN");
         return s2d.StringToDouble(buffer, length, processed_characters_count);
     }
   }

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -32,7 +32,7 @@ namespace double_conversion
                  "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
         StringBuilder sb(buf, buflen);
         int success =  static_cast<int>(d2s.ToShortest(value, &sb));
-        success = success && (!allow_nan || ((strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0)));
+        success = success && (!allow_nan || ((strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0 && strcmp(buf, "-Infinity") != 0)));
         *strlength = success ? sb.position() : -1;
         return success;
     }

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -29,17 +29,10 @@ namespace double_conversion
     int dconv_d2s(double value, char* buf, int buflen, int* strlength, int allow_nan)
     {
         static auto d2s = DoubleToStringConverter(DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
-                 "Inf", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
-        if(allow_nan)
-        {
-            d2s.nan_symbol_ = "NaN";
-            d2s.infinity_symbol_ = "Infinity";
-        }else{
-            d2s.nan_symbol_ = NULL;
-            d2s.infinity_symbol_ = NULL;
-        }
+                 "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
         StringBuilder sb(buf, buflen);
         int success =  static_cast<int>(d2s.ToShortest(value, &sb));
+        success = success && (!allow_nan || (strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0));
         *strlength = success ? sb.position() : -1;
         return success;
     }

--- a/lib/dconv_wrapper.cc
+++ b/lib/dconv_wrapper.cc
@@ -32,7 +32,7 @@ namespace double_conversion
                  "Infinity", "NaN", 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
         StringBuilder sb(buf, buflen);
         int success =  static_cast<int>(d2s.ToShortest(value, &sb));
-        success = success && (!allow_nan || (strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0));
+        success = success && (!allow_nan || ((strcmp(buf, "NaN") != 0 && strcmp(buf, "Infinity") != 0)));
         *strlength = success ? sb.position() : -1;
         return success;
     }

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -347,49 +347,11 @@ typedef struct __JSONObjectDecoder
   char *errorStr;
   char *errorOffset;
   void *prv;
-  void *s2d;
 } JSONObjectDecoder;
 
 EXPORTFUNCTION JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuffer);
 
-#define DCONV_DECIMAL_IN_SHORTEST_LOW -4
-#define DCONV_DECIMAL_IN_SHORTEST_HIGH 16
-
-enum dconv_d2s_flags {
-  DCONV_D2S_NO_FLAGS = 0,
-  DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN = 1,
-  DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT = 2,
-  DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT = 4,
-  DCONV_D2S_UNIQUE_ZERO = 8
-};
-
-enum dconv_s2d_flags
-{
-  DCONV_S2D_NO_FLAGS = 0,
-  DCONV_S2D_ALLOW_HEX = 1,
-  DCONV_S2D_ALLOW_OCTALS = 2,
-  DCONV_S2D_ALLOW_TRAILING_JUNK = 4,
-  DCONV_S2D_ALLOW_LEADING_SPACES = 8,
-  DCONV_S2D_ALLOW_TRAILING_SPACES = 16,
-  DCONV_S2D_ALLOW_SPACES_AFTER_SIGN = 32
-};
-
-void dconv_d2s_init(void **d2s,
-                    int flags,
-                    const char* infinity_symbol,
-                    const char* nan_symbol,
-                    char exponent_character,
-                    int decimal_in_shortest_low,
-                    int decimal_in_shortest_high,
-                    int max_leading_padding_zeroes_in_precision_mode,
-                    int max_trailing_padding_zeroes_in_precision_mode);
-int dconv_d2s(void *d2s, double value, char* buf, int buflen, int* strlength);
-void dconv_d2s_free(void **d2s);
-
-void dconv_s2d_init(void **s2d, int flags, double empty_string_value,
-                    double junk_string_value, const char* infinity_symbol,
-                    const char* nan_symbol);
-double dconv_s2d(void *s2d, const char* buffer, int length, int* processed_characters_count);
-void dconv_s2d_free(void **s2d);
+int dconv_d2s(double value, char* buf, int buflen, int* strlength, int allow_nan);
+double dconv_s2d(const char* buffer, int length, int* processed_characters_count);
 
 #endif

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -82,7 +82,7 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodeDouble(struct DecoderState *ds)
   /* Prevent int overflow if ds->end - ds->start is too large. See check_decode_decimal_no_int_overflow()
   inside tests/test_ujson.py for an example where this check is necessary. */
   int len = ((size_t) (ds->end - ds->start) < (size_t) INT_MAX) ? (int) (ds->end - ds->start) : INT_MAX;
-  double value = dconv_s2d(ds->dec->s2d, ds->start, len, &processed_characters_count);
+  double value = dconv_s2d(ds->start, len, &processed_characters_count);
   ds->lastType = JT_DOUBLE;
   ds->start += processed_characters_count;
   return ds->dec->newDouble(ds->prv, value);

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -643,7 +643,7 @@ static int Buffer_AppendDoubleDconv(JSOBJ obj, JSONObjectEncoder *enc, double va
     abort();
   }
 #endif
-  if(!dconv_d2s(enc->d2s, value, buf, sizeof(buf), &strlength))
+  if(!dconv_d2s(value, buf, sizeof(buf), &strlength, enc->allowNan))
   {
     SetError (obj, enc, "Invalid value when encoding double");
     return FALSE;

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -232,12 +232,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
   decoder.errorStr = NULL;
   decoder.errorOffset = NULL;
 
-  decoder.s2d = NULL;
-  dconv_s2d_init(&decoder.s2d, DCONV_S2D_ALLOW_TRAILING_JUNK, 0.0, 0.0, "Infinity", "NaN");
-
   ret = JSON_DecodeObject(&decoder, raw, sarg_length);
-
-  dconv_s2d_free(&decoder.s2d);
 
   if (!is_bytes_like)
   {

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -750,12 +750,6 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     encoder.prv = odefaultFn;
   }
 
-  if (encoder.allowNan)
-  {
-    csInf = "Infinity";
-    csNan = "NaN";
-  }
-
   if (orejectBytes != -1)
   {
     encoder.rejectBytes = orejectBytes;
@@ -816,15 +810,10 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     }
   }
 
-  encoder.d2s = NULL;
-  dconv_d2s_init(&encoder.d2s, DCONV_D2S_EMIT_TRAILING_DECIMAL_POINT | DCONV_D2S_EMIT_TRAILING_ZERO_AFTER_POINT | DCONV_D2S_EMIT_POSITIVE_EXPONENT_SIGN,
-                 csInf, csNan, 'e', DCONV_DECIMAL_IN_SHORTEST_LOW, DCONV_DECIMAL_IN_SHORTEST_HIGH, 0, 0);
-
   PRINTMARK();
   ret = JSON_EncodeObject (oinput, &encoder, buffer, sizeof (buffer), &retLen);
   PRINTMARK();
 
-  dconv_d2s_free(&encoder.d2s);
   Py_XDECREF(separatorsItemBytes);
   Py_XDECREF(separatorsKeyBytes);
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Use library static lifetime for google-double converter instance to avoid malloc and free every time
* side-effect: it will disable we to pass args dynamically
* due to ujson didn't set C++ standard version, multi-thread safty for `static` variable may not be promised
