### PR TITLE
Test Python 3.13 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.10", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy-3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
           - { python-version: "pypy-3.10", os: windows-latest }
           - { python-version: "pypy-3.10", os: macos-latest }
-          - { python-version: "3.10", os: windows-latest }
-          - { python-version: "3.10", os: macos-latest }
-          - { python-version: "3.11", os: windows-latest }
-          - { python-version: "3.11", os: macos-latest }
+          - { python-version: "3.12", os: windows-latest }
+          - { python-version: "3.12", os: macos-latest }
+          - { python-version: "3.13", os: windows-latest }
+          - { python-version: "3.13", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The 3.13 beta is out, time to start testing: https://discuss.python.org/t/python-3-13-0b1-now-available/52891

cibuildwheel isn't quite ready for 3.13.