### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       # https://github.com/pypa/cibuildwheel
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.18.0
         with:
           output-dir: dist
         # Options are supplied via environment variables:
@@ -71,6 +71,7 @@ jobs:
           - cp310
           - cp311
           - cp312
+          - cp313
 
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +90,7 @@ jobs:
 
       # https://github.com/pypa/cibuildwheel
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.18.0
         with:
           output-dir: dist
         # Options are supplied via environment variables:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,6 @@ repos:
     rev: v2.5.0
     hooks:
       - id: setup-cfg-fmt
-        args: [--include-version-classifiers, --max-py-version=3.12]
+        args: [--include-version-classifiers, --max-py-version=3.13]
 ci:
   autoupdate_schedule: quarterly

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 download_url = https://github.com/ultrajson/ultrajson
 project_urls =
     Source=https://github.com/ultrajson/ultrajson


### PR DESCRIPTION
Follow on from https://github.com/ultrajson/ultrajson/pull/627:

> cibuildwheel isn't quite ready for 3.13.

And now it is :)

https://github.com/pypa/cibuildwheel/releases/tag/v2.18.0

About publishing beta wheels: it will help others test out the beta and to report problems back to CPython to be fixed before the full release in October. 

It is possible the ABI can change during beta, but it's pretty rate, and we can easily publish new wheels need be.
