### PR TITLE
Pin setuptools < 72.2 to fix build on PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42,<72.2", "setuptools_scm[toml]>=3.4"]
 
 [tool.black]
 target_version = ["py38"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=42,<72.2", "setuptools_scm[toml]>=3.4"]
+requires = [
+  "setuptools>=42",
+  'setuptools<72.2; implementation_name == "pypy"', # https://github.com/pypa/distutils/issues/283
+  "setuptools_scm[toml]>=3.4",
+]
 
 [tool.black]
 target_version = ["py38"]


### PR DESCRIPTION
https://github.com/ultrajson/ultrajson/pull/637 failed for PyPy on Ubuntu and macOS (but not Windows):

```pytb
          self.link(
        File "/tmp/pip-build-env-0i2_clgx/overlay/lib/pypy3.10/site-packages/setuptools/_distutils/unixccompiler.py", line 268, in link
          linker = (
      TypeError: 'NoneType' object is not subscriptable (key slice(None, None, None))

```
https://github.com/ultrajson/ultrajson/actions/runs/10650149917/job/29521178562?pr=637

Our last passing build was on 1st August: https://github.com/ultrajson/ultrajson/pull/636 (these regular dependabot PRs are useful after all!)

It looks like a setuptools thing. I tried setuptools 72.1, the current on 1st August, which worked, and found the first failure happened with 72.2, released on 2nd August.

https://setuptools.pypa.io/en/stable/history.html#v72-2-0

setuptools 72.2 had changes related to distutils and compilers, which tracks with the traceback above:

> Merged with [pypa/distutils@b7ee725f3](https://github.com/pypa/distutils/commit/b7ee725f3) including: Support for Pathlike objects in data files and extensions ([pypa/distutils#272](https://github.com/pypa/distutils/issues/272), [pypa/distutils#237](https://github.com/pypa/distutils/issues/237)), native support for C++ compilers ([pypa/distuils#228](https://github.com/pypa/distuils/issues/228)) and removed unused get_msvcr() ([pypa/distutils#274](https://github.com/pypa/distutils/issues/274)). ([#4538](https://github.com/pypa/setuptools/issues/4538))

I'll report this to setuptools.

And let's pin an upper setuptools version for the build backend for now.
