### PR TITLE
Drop support for EOL PyPy3.8 and PyPy3.9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64 i686"
           # Include latest Python beta.
           CIBW_PRERELEASE_PYTHONS: True
+          # Skip EOL Python versions.
+          CIBW_SKIP: "pp38* pp39*"
           # Run the test suite after each build.
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: pytest {package}/tests
@@ -64,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - pp39
           - pp310
           - cp38
           - cp39


### PR DESCRIPTION
Last week's PyPy release dropped PyPy3.9:

* https://pypy.org/posts/2024/08/pypy-v7317-release.html#pypy-versions-and-speed-pypy-org

We already removed PyPy3.8 from the wheel build in https://github.com/ultrajson/ultrajson/pull/602, but only for the `build-QEMU-emulated-wheels` job which has a version matrix.

The `build-native-wheels` job was still building the cibuildwheel default, which includes PyPy3.8 and PyPy3.9:

If we unzip the `wheels-*-latest` zips at https://github.com/ultrajson/ultrajson/actions/runs/10666436368 we can see the pp38 (and pp39) wheels. Also at https://pypi.org/project/ujson/5.10.0/#files.

Let's explicitly exclude them with `CIBW_SKIP`.

---

The Python 3.8 EOL is due some time next month, shall we also drop that already or wait until next month?

https://peps.python.org/pep-0569/#lifespan