### PR TITLE
Always use Python from actions/setup-python

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
 
       - name: Install
         run: |


### PR DESCRIPTION
The Ubuntu runners have finally upgraded their system version of Python/pip to one with the guard against using pip to potentially clobber apt-get managed environments.