### PR TITLE
Add zizmor to pre-commit

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  artipacked:
+    ignore:
+      - benchmark.yml
+      - deploy.yml
+      - fuzz.yml
+      - labels.yml
+      - lint.yml
+      - test.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         args: [--target-version=py39]
@@ -39,8 +39,13 @@ repos:
       - id: trailing-whitespace
         exclude: "^.github/.*_TEMPLATE.md"
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.9.1
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.5.0
+    rev: v2.7.0
     hooks:
       - id: setup-cfg-fmt
         args: [--include-version-classifiers, --max-py-version=3.13]


### PR DESCRIPTION
https://github.com/woodruffw/zizmor is a static analysis tool for GitHub Actions and can find potential security issues.

The one found here are all straightforward:

```diff
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
```
