### PR TITLE
Build aarch64 wheels using native runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,21 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build-native-wheels:
+  build-wheels:
+    name: "${{ matrix.os }}: ${{ matrix.cibw_arch }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
-
+        include:
+          - os: windows-latest
+            cibw_arch: "auto"
+          - os: macos-latest
+            cibw_arch: "x86_64 arm64"
+          - os: ubuntu-latest
+            cibw_arch: "x86_64 i686"
+          - os: ubuntu-24.04-arm
+            cibw_arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow
@@ -40,10 +48,8 @@ jobs:
           output-dir: dist
         # Options are supplied via environment variables:
         env:
-          # Build separate wheels for macOS's different architectures.
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          # Build only on Linux architectures that don't need qemu emulation.
-          CIBW_ARCHS_LINUX: "x86_64 i686"
+          # Build wheels for the currently selected architecture.
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
           # Include latest Python beta.
           CIBW_ENABLE: cpython-prerelease
           # Skip EOL Python versions.
@@ -58,61 +64,9 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: dist/*.whl
 
-  build-QEMU-emulated-wheels:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - pp310
-          - cp39
-          - cp310
-          - cp311
-          - cp312
-          - cp313
-
-    steps:
-      - uses: actions/checkout@v4
-      - run: git fetch --prune --unshallow
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-          cache-dependency-path: ".github/workflows/deploy.yml"
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/pypa/cibuildwheel
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        with:
-          output-dir: dist
-        # Options are supplied via environment variables:
-        env:
-          # Build only the currently selected Linux architecture (so we can
-          # parallelise for speed).
-          CIBW_ARCHS_LINUX: "aarch64"
-          # Likewise, select only one Python version per job to speed this up.
-          CIBW_BUILD: "${{ matrix.python-version }}-*"
-          # Include latest Python beta.
-          CIBW_ENABLE: cpython-prerelease
-          # Run the test suite after each build.
-          CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: pytest {package}/tests
-
-      - name: Upload as build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-qemu-${{ matrix.python-version }}
-          path: dist/*.whl
-
   build-sdist-and-upload:
     runs-on: ubuntu-latest
-    needs: ['build-native-wheels', 'build-QEMU-emulated-wheels']
+    needs: ['build-wheels']
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           # Build wheels for the currently selected architecture.
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           # Include latest Python beta.
-          CIBW_ENABLE: cpython-prerelease
+          CIBW_ENABLE: cpython-prerelease pypy
           # Skip EOL Python versions.
           CIBW_SKIP: "pp39*"
           # Run the test suite after each build.


### PR DESCRIPTION
GitHub Actions now has free hosted Arm runners:

https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/

That means we can replace the slow QEMU jobs with native `ubuntu-24.04-arm` to build the `aarch64` wheels in a single job.


<table>
<tr>
<th>
<th><a href="https://github.com/ultrajson/ultrajson/actions/runs/12649398956">Before</a>
<th><a href="https://github.com/ultrajson/ultrajson/actions/runs/12845367625">After</a>
<tr>
<td>Jobs
<td>10
<td>5
<tr>
<td>Total duration
<td>10m 27s
<td>10m 37s
<tr>
<td>Run time
<td>53m 2s
<td>25m 23s
</table>



---

Also fix a warning by adding `pypy` to `CIBW_ENABLE`:

> PyPy builds will be disabled by default in version 3. Enabling PyPy builds should be specified by enable
