### PR TITLE
Add support for PyPy3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy-3.11", "pypy-3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
-          - { python-version: "pypy-3.10", os: windows-latest }
-          - { python-version: "pypy-3.10", os: macos-latest }
-          - { python-version: "3.12", os: windows-latest }
-          - { python-version: "3.12", os: macos-latest }
+          - { python-version: "pypy-3.11", os: windows-latest }
+          - { python-version: "pypy-3.11", os: macos-latest }
           - { python-version: "3.13", os: windows-latest }
           - { python-version: "3.13", os: macos-latest }
 


### PR DESCRIPTION
The latest PyPy v7.3.19 release includes a 3.11 beta:

> This release includes a python 3.11 interpreter. There were bugs in the first [v7.3.18] beta that could prevent its wider use, so we are continuing to call this release "beta". In the next release we will drop 3.10 and remove the "beta" label.

https://pypy.org/posts/2025/02/pypy-v7319-release.html

cibuildwheel also now supports PyPy3.11 and with the merge of https://github.com/ultrajson/ultrajson/pull/657 we get both PyPy3.10 and 3.11 wheels:

https://github.com/ultrajson/ultrajson/actions/runs/13606089044/job/38037728346?pr=657#step:5:1775