### PR TITLE
fix(ujson.loads): raises a JSONDecodeError instead of SystemError when parsing a nested json string

### DIFF
--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1216,6 +1216,20 @@ def test_enum(enum_classes, value, expected):
     assert ujson.dumps(MyEnum.FOO) == expected
 
 
+def test_nested_json_decode_error():
+    """Test that parsing a nested json string raises JSONDecodeError and not SystemError."""
+    
+    # Test that nested JSON with invalid format raises JSONDecodeError
+    with pytest.raises(ujson.JSONDecodeError):
+        ujson.loads(b'{{"a":"b"}:"c"}')
+    
+    # Test with another nested JSON case
+    with pytest.raises(ujson.JSONDecodeError):
+        ujson.loads('{"a":{"b":"c"}:"d"}')
+    
+    # Test that JSONDecodeError is a subclass of ValueError
+    assert issubclass(ujson.JSONDecodeError, ValueError)
+
 """
 The following checks are not part of the standard test suite.
 They can be run manually as follows:

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1217,7 +1217,7 @@ def test_enum(enum_classes, value, expected):
 
 
 def test_nested_json_decode_error():
-    """Test that parsing a nested json string raises JSONDecodeError and not SystemError."""
+    """Parsing a nested json string raises JSONDecodeError and not SystemError."""
 
     # Test that nested JSON with invalid format raises JSONDecodeError
     with pytest.raises(ujson.JSONDecodeError):

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1218,17 +1218,18 @@ def test_enum(enum_classes, value, expected):
 
 def test_nested_json_decode_error():
     """Test that parsing a nested json string raises JSONDecodeError and not SystemError."""
-    
+
     # Test that nested JSON with invalid format raises JSONDecodeError
     with pytest.raises(ujson.JSONDecodeError):
         ujson.loads(b'{{"a":"b"}:"c"}')
-    
+
     # Test with another nested JSON case
     with pytest.raises(ujson.JSONDecodeError):
         ujson.loads('{"a":{"b":"c"}:"d"}')
-    
+
     # Test that JSONDecodeError is a subclass of ValueError
     assert issubclass(ujson.JSONDecodeError, ValueError)
+
 
 """
 The following checks are not part of the standard test suite.


### PR DESCRIPTION
Fixes https://github.com/ultrajson/ultrajson/issues/656

Changes proposed in this pull request:

* add check when adding key
* raises a JSONDecodeError instead of SystemError when parsing a nested json string