### PR TITLE
Test Python 3.14 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.11", "pypy-3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy-3.11", "pypy-3.10", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
         include:
           - { python-version: "pypy-3.11", os: windows-latest }
           - { python-version: "pypy-3.11", os: macos-latest }
           - { python-version: "3.13", os: windows-latest }
           - { python-version: "3.13", os: macos-latest }
+          # - { python-version: "3.14", os: windows-latest } pending https://github.com/python/cpython/issues/133779
+          - { python-version: "3.14", os: macos-latest }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The 3.14 beta is out, time to start testing: https://discuss.python.org/t/python-3-14-0-beta-1-is-here/91117

cibuildwheel isn't quite ready for 3.14, but should be soonish: https://github.com/pypa/cibuildwheel/issues/2047#issuecomment-2862585414

Seems there's a linking problem with GitHub's Windows build of 3.14, let's skip it for now:

* https://github.com/hugovk/ultrajson/actions/runs/14948754300/job/41995519911
* https://github.com/python/cpython/issues/133779
