### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: rst-backticks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -40,7 +40,7 @@ repos:
         exclude: "^.github/.*_TEMPLATE.md"
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.11.0
+    rev: v1.12.1
     hooks:
       - id: zizmor
 
@@ -48,10 +48,10 @@ repos:
     rev: v2.8.0
     hooks:
       - id: setup-cfg-fmt
-        args: [--include-version-classifiers, --max-py-version=3.13]
+        args: [--include-version-classifiers, --max-py-version=3.14]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.5.0
+    rev: 1.6.0
     hooks:
       - id: tox-ini-fmt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Typing :: Typed
 download_url = https://github.com/ultrajson/ultrajson
 project_urls =


### PR DESCRIPTION
We're already testing it (https://github.com/ultrajson/ultrajson/pull/668) and building wheels (cibuildwheel 3.0 added support in https://github.com/ultrajson/ultrajson/pull/676, see `cp314` wheels at https://github.com/ultrajson/ultrajson/actions/runs/16775927977).

This PR adds the Trove classifier.