### PR TITLE
Test free-threaded Python 3.13t and 3.14t

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.11", "pypy-3.10", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - "pypy3.11"
+          - "3.14t"
+          - "3.14"
+          - "3.13t"
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
         os: [ubuntu-latest]
         include:
           - { python-version: "pypy-3.11", os: windows-latest }
@@ -33,6 +42,11 @@ jobs:
           allow-prereleases: true
           cache: pip
           cache-dependency-path: "setup.py"
+
+      - name: Set PYTHON_GIL
+        if: endsWith(matrix.python-version, 't')
+        run: |
+          echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           - { python-version: "pypy-3.11", os: macos-latest }
           - { python-version: "3.13", os: windows-latest }
           - { python-version: "3.13", os: macos-latest }
-          # - { python-version: "3.14", os: windows-latest } pending https://github.com/python/cpython/issues/133779
+          - { python-version: "3.14", os: windows-latest }
           - { python-version: "3.14", os: macos-latest }
 
     steps:


### PR DESCRIPTION
We haven't done anything to explicitly support free-threaded Python, and there may well be code and test changes needed to support it.

Shall we at least start running the existing tests on free-threaded?

With cibuildwheel 3.0 in https://github.com/ultrajson/ultrajson/pull/676, we also get free-threaded 3.14 wheels (see `cp314t` at https://github.com/ultrajson/ultrajson/actions/runs/16775927977) which means others will be able to test it further.

---

https://github.com/python/cpython/issues/133779 is also fixed and we can continue testing (regular) 3.14 on Windows.
