### PR TITLE
Drop support for EOL PyPy3.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           # Include latest Python beta.
           CIBW_ENABLE: cpython-prerelease pypy
           # Skip EOL Python versions.
-          CIBW_SKIP: "pp39*"
+          CIBW_SKIP: "pp310*"
           # Run the test suite after each build.
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: pytest {package}/tests


### PR DESCRIPTION
Changes proposed in this pull request:

* The latest PyPy supports 3.11 but no longer 3.10
* A future cibuildwheel release will remove PyPy 3.10 from the default (https://github.com/pypa/cibuildwheel/pull/2521) but for now let's explicitly skip it
* Let's remove PyPy 3.9 from the skip to avoid a [warning](https://github.com/ultrajson/ultrajson/actions/runs/16775927977):
  * > cibuildwheel: Invalid skip selector: 'pp39*'. This selector matches a group that wasn't enabled. Enable it using the `enable` option or remove this selector. This selector will have no effect.

