### PR TITLE
thread safety fixes for free-threading

### DIFF
--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -60,6 +60,11 @@ https://opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #define snprintf sprintf_s
 #endif
 
+#if PY_VERSION_HEX < 0x030D00B3
+#  define Py_BEGIN_CRITICAL_SECTION(op) {
+#  define Py_END_CRITICAL_SECTION() }
+#endif
+
 /*
 Worst cases being:
 

--- a/src/ujson/python/ujson.c
+++ b/src/ujson/python/ujson.c
@@ -200,6 +200,8 @@ PyMODINIT_FUNC PyInit_ujson(void)
     Py_DECREF(module);
     return NULL;
   }
+#ifdef Py_GIL_DISABLED
   PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
   return module;
 }

--- a/src/ujson/python/ujson.c
+++ b/src/ujson/python/ujson.c
@@ -200,6 +200,6 @@ PyMODINIT_FUNC PyInit_ujson(void)
     Py_DECREF(module);
     return NULL;
   }
-
+  PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   return module;
 }

--- a/tests/test_ft.py
+++ b/tests/test_ft.py
@@ -1,0 +1,68 @@
+from threading import Thread, Barrier
+import ujson
+import random
+
+def test_list_thread_safety():
+    matrix = [[i + j * 100 for i in range(100)] for j in range(100)]
+    barrier = Barrier(10)
+    def test():
+        barrier.wait()
+        for _ in range(1000):
+            row = random.randint(0, 99)
+            col = random.randint(0, 99)
+            matrix[row][col] = random.randint(0, 10000)
+        serialized = ujson.dumps(matrix)
+        deserialized = ujson.loads(serialized)
+        assert all([len(row) == 100 for row in deserialized])
+        assert all([deserialized[i][j] <= 10000 for i in range(100) for j in range(100)])
+
+    threads = [Thread(target=test) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def test_dict_thread_safety():
+    data = {f'key_{i}': i for i in range(1000)}
+    barrier = Barrier(10)
+    def test():
+        barrier.wait()
+        for _ in range(1000):
+            key = f'key_{random.randint(0, 999)}'
+            data[key] = random.randint(0, 10000)
+        serialized = ujson.dumps(data)
+        deserialized = ujson.loads(serialized)
+        assert all([deserialized[f'key_{i}'] <= 10000 for i in range(1000)])
+
+    threads = [Thread(target=test) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+def test_mixed_thread_safety():
+    mixed_data = {
+        'numbers': [i for i in range(1000)],
+        'mapping': {f'key_{i}': i for i in range(1000)},
+        'nested': [{'id': i, 'value': i * 2} for i in range(1000)]
+    }
+    barrier = Barrier(10)
+    def test():
+        barrier.wait()
+        for _ in range(1000):
+            index = random.randint(0, 999)
+            mixed_data['numbers'][index] = random.randint(0, 10000)
+            mixed_data['mapping'][f'key_{index}'] = random.randint(0, 10000)
+            mixed_data['nested'][index]['value'] = random.randint(0, 20000)
+        serialized = ujson.dumps(mixed_data)
+        deserialized = ujson.loads(serialized)
+        assert all([deserialized['numbers'][i] <= 10000 for i in range(1000)])
+        assert all([deserialized['mapping'][f'key_{i}'] <= 10000 for i in range(1000)])
+        assert all([deserialized['nested'][i]['value'] <= 20000 for i in range(1000)])
+
+    threads = [Thread(target=test) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()

--- a/tests/test_ft.py
+++ b/tests/test_ft.py
@@ -1,10 +1,13 @@
-from threading import Thread, Barrier
-import ujson
 import random
+from threading import Barrier, Thread
+
+import ujson
+
 
 def test_list_thread_safety():
     matrix = [[i + j * 100 for i in range(100)] for j in range(100)]
     barrier = Barrier(10)
+
     def test():
         barrier.wait()
         for _ in range(1000):
@@ -14,7 +17,9 @@ def test_list_thread_safety():
         serialized = ujson.dumps(matrix)
         deserialized = ujson.loads(serialized)
         assert all([len(row) == 100 for row in deserialized])
-        assert all([deserialized[i][j] <= 10000 for i in range(100) for j in range(100)])
+        assert all(
+            [deserialized[i][j] <= 10000 for i in range(100) for j in range(100)]
+        )
 
     threads = [Thread(target=test) for _ in range(10)]
     for thread in threads:
@@ -24,16 +29,17 @@ def test_list_thread_safety():
 
 
 def test_dict_thread_safety():
-    data = {f'key_{i}': i for i in range(1000)}
+    data = {f"key_{i}": i for i in range(1000)}
     barrier = Barrier(10)
+
     def test():
         barrier.wait()
         for _ in range(1000):
-            key = f'key_{random.randint(0, 999)}'
+            key = f"key_{random.randint(0, 999)}"
             data[key] = random.randint(0, 10000)
         serialized = ujson.dumps(data)
         deserialized = ujson.loads(serialized)
-        assert all([deserialized[f'key_{i}'] <= 10000 for i in range(1000)])
+        assert all([deserialized[f"key_{i}"] <= 10000 for i in range(1000)])
 
     threads = [Thread(target=test) for _ in range(10)]
     for thread in threads:
@@ -41,25 +47,27 @@ def test_dict_thread_safety():
     for thread in threads:
         thread.join()
 
+
 def test_mixed_thread_safety():
     mixed_data = {
-        'numbers': [i for i in range(1000)],
-        'mapping': {f'key_{i}': i for i in range(1000)},
-        'nested': [{'id': i, 'value': i * 2} for i in range(1000)]
+        "numbers": [i for i in range(1000)],
+        "mapping": {f"key_{i}": i for i in range(1000)},
+        "nested": [{"id": i, "value": i * 2} for i in range(1000)],
     }
     barrier = Barrier(10)
+
     def test():
         barrier.wait()
         for _ in range(1000):
             index = random.randint(0, 999)
-            mixed_data['numbers'][index] = random.randint(0, 10000)
-            mixed_data['mapping'][f'key_{index}'] = random.randint(0, 10000)
-            mixed_data['nested'][index]['value'] = random.randint(0, 20000)
+            mixed_data["numbers"][index] = random.randint(0, 10000)
+            mixed_data["mapping"][f"key_{index}"] = random.randint(0, 10000)
+            mixed_data["nested"][index]["value"] = random.randint(0, 20000)
         serialized = ujson.dumps(mixed_data)
         deserialized = ujson.loads(serialized)
-        assert all([deserialized['numbers'][i] <= 10000 for i in range(1000)])
-        assert all([deserialized['mapping'][f'key_{i}'] <= 10000 for i in range(1000)])
-        assert all([deserialized['nested'][i]['value'] <= 20000 for i in range(1000)])
+        assert all([deserialized["numbers"][i] <= 10000 for i in range(1000)])
+        assert all([deserialized["mapping"][f"key_{i}"] <= 10000 for i in range(1000)])
+        assert all([deserialized["nested"][i]["value"] <= 20000 for i in range(1000)])
 
     threads = [Thread(target=test) for _ in range(10)]
     for thread in threads:


### PR DESCRIPTION
Fixes #684

Changes proposed in this pull request:

This PR fixes the thread safety issues of ujson in free-threading:

* Adds critical section on the object being serialized
* Switches to strong references instead of borrowed ones as the former is not safe in free-threading
* Adds some thread safety tests where dicts and lists are mutated concurrently while serializing 
