### PR TITLE
Update license field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ultrajson/ultrajson
 author = Jonas Tarnstrom
+license = BSD-3-Clause AND TCL
 license_files = LICENSE.txt
 platforms = any
 classifiers =


### PR DESCRIPTION
Fixes #692

With [PEP 639](https://peps.python.org/pep-0639/), the standard for license is [SPDX](https://spdx.org/licenses/).
So I think this refers to [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) and [TCL](https://spdx.org/licenses/TCL.html).
The SPDX supports multiple licenses with the [and-operator](https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#conjunctive-and-operator)

This makes it easier for tools to determine which license is used.

Changes proposed in this pull request:

* Add licenses tothe  license field
