### PR TITLE
Add riscv64 manylinux/musllinux wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
             cibw_arch: "x86_64 i686"
           - os: ubuntu-24.04-arm
             cibw_arch: aarch64
+          - os: ubuntu-24.04
+            cibw_arch: riscv64
     steps:
       - uses: actions/checkout@v5
       - run: git fetch --prune --unshallow
@@ -44,6 +46,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+
+      - name: Set up QEMU
+        if: matrix.cibw_arch == 'riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
 
       # https://github.com/pypa/cibuildwheel
       - name: Build wheels


### PR DESCRIPTION
Now that cibuildwheel and PyPI support riscv64, we can start building riscv64 wheels for ultrajson.

Because there is no native riscv64 runner available, this PR adds a QEMU-based riscv64 job to the cibuildwheel workflow.

Fixes #694 
