### PR TITLE
Remove upper bound of setuptools for PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=42",
-  'setuptools<72.2; implementation_name == "pypy"', # https://github.com/pypa/distutils/issues/283
   "setuptools_scm[toml]>=3.4",
 ]
 


### PR DESCRIPTION
Closes https://github.com/ultrajson/ultrajson/pull/702.

I'm not sure what changed, but https://github.com/ultrajson/ultrajson/pull/702 passed on PyPy, so we don't need the upper `<72.2` bound any more. 

I also tested `setuptools==72.2`, and that's now passing: https://github.com/hugovk/ultrajson/actions/runs/22541984458/job/65298465183
