### PR TITLE
Add leak detection to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,10 @@ jobs:
           ./scripts/coverage.sh
           bash <(curl -s https://codecov.io/bash) -X gcov
 
+      - name: Test with leak detection
+        if: "!startsWith(matrix.python-version, 'pypy') && !endsWith(matrix.python-version, 't')"
+        run: python -m pytest --leak-max-loops=5000 -v
+
   cross-arch:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ target_version = ["py310"]
 [tool.isort]
 profile = "black"
 known_first_party = ["ujson"]
+
+[tool.pytest]
+markers = [
+    "skip_leak_test: Don't rerun this test in search for memory leaks"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+import gc
+
+try:
+    import tracemalloc
+except ImportError:  # PyPy
+    pass
+import functools
+
+import pytest
+
+
+def pytest_addoption(parser, pluginmanager):
+    parser.addoption(
+        "--leak-max-loops",
+        type=int,
+        help="Run each test repeatedly until its memory consumption plateaus",
+    )
+
+
+def add_leak_detection(function, max_loops):
+
+    @functools.wraps(function)
+    def wrapped(*args, **kwargs):
+        try:
+            # A test is considered not leaky if its high tide memory usage has not
+            # increased in the last 50% of or 10 iterations (whichever is larger).
+            tracemalloc.start()
+            function(*args, **kwargs)
+            gc.collect()
+            baseline = tracemalloc.get_traced_memory()[0]
+            before = baseline
+            last_increase = 0
+            for i in range(max_loops):
+                function(*args, **kwargs)
+                gc.collect()
+                current, _ = tracemalloc.get_traced_memory()
+                print(i, last_increase, current - baseline, current - before)
+                if current <= before:
+                    if i >= max(10, last_increase + i // 2):
+                        break
+                else:
+                    last_increase = i
+                    before = current
+                if last_increase > max_loops // 2:
+                    leaked = current - baseline
+                    pytest.fail(f"{leaked}B leaked ({leaked / (i + 1)} per iteration)")
+        finally:
+            tracemalloc.stop()
+
+    return wrapped
+
+
+def pytest_collection_modifyitems(session, config, items):
+    if config.option.leak_max_loops:
+        for test in items:
+            if test.get_closest_marker("skip_leak_test") is None:
+                test.obj = add_leak_detection(test.obj, config.option.leak_max_loops)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1,3 +1,4 @@
+import copy
 import datetime as dt
 import decimal
 import enum
@@ -289,22 +290,18 @@ def test_decode_from_unicode():
     assert dec1 == dec2
 
 
+class O1:
+    member = 0
+
+    def toDict(self):
+        return {"member": self.member}
+
+
+@pytest.mark.skip_leak_test  # Known memory leak
 def test_encode_recursion_max():
     # 8 is the max recursion depth
-    class O2:
-        member = 0
-
-        def toDict(self):
-            return {"member": self.member}
-
-    class O1:
-        member = 0
-
-        def toDict(self):
-            return {"member": self.member}
-
     test_input = O1()
-    test_input.member = O2()
+    test_input.member = O1()
     test_input.member.member = test_input
     with pytest.raises((OverflowError, RecursionError)):
         ujson.encode(test_input)
@@ -352,15 +349,16 @@ def test_dump_to_file():
     assert "[1,2,3]" == f.getvalue()
 
 
+class WritableFileLike:
+    def __init__(self):
+        self.bytes = ""
+
+    def write(self, bytes):
+        self.bytes += bytes
+
+
 def test_dump_to_file_like_object():
-    class FileLike:
-        def __init__(self):
-            self.bytes = ""
-
-        def write(self, bytes):
-            self.bytes += bytes
-
-    f = FileLike()
+    f = WritableFileLike()
     ujson.dump([1, 2, 3], f)
     assert "[1,2,3]" == f.bytes
 
@@ -375,16 +373,17 @@ def test_load_file():
     assert [1, 2, 3, 4] == ujson.load(f)
 
 
-def test_load_file_like_object():
-    class FileLike:
-        def read(self):
-            try:
-                self.end
-            except AttributeError:
-                self.end = True
-                return "[1,2,3,4]"
+class ReadableFileLike:
+    def read(self):
+        try:
+            self.end
+        except AttributeError:
+            self.end = True
+            return "[1,2,3,4]"
 
-    f = FileLike()
+
+def test_load_file_like_object():
+    f = ReadableFileLike()
     assert [1, 2, 3, 4] == ujson.load(f)
 
 
@@ -428,47 +427,43 @@ def test_decode_big_escape():
         ujson.decode(test_input)
 
 
+class DictTest:
+    def toDict(self):
+        return dict(key=31337)
+
+    def __json__(self):
+        return '"json defined"'  # Fallback and shouldn't be called.
+
+
 def test_to_dict():
-    d = {"key": 31337}
-
-    class DictTest:
-        def toDict(self):
-            return d
-
-        def __json__(self):
-            return '"json defined"'  # Fallback and shouldn't be called.
-
     o = DictTest()
     output = ujson.encode(o)
     dec = ujson.decode(output)
-    assert dec == d
+    assert dec == {"key": 31337}
+
+
+class JSONTest:
+    def __init__(self, output):
+        self.output = output
+
+    def __json__(self):
+        return copy.deepcopy(self.output)
 
 
 def test_object_with_json():
     # If __json__ returns a string, then that string
     # will be used as a raw JSON snippet in the object.
-    output_text = "this is the correct output"
-
-    class JSONTest:
-        def __json__(self):
-            return '"' + output_text + '"'
-
-    d = {"key": JSONTest()}
+    d = {"key": JSONTest('"this is the correct output"')}
     output = ujson.encode(d)
     dec = ujson.decode(output)
-    assert dec == {"key": output_text}
+    assert dec == {"key": "this is the correct output"}
 
 
 def test_object_with_complex_json():
     # If __json__ returns a string, then that string
     # will be used as a raw JSON snippet in the object.
     obj = {"foo": ["bar", "baz"]}
-
-    class JSONTest:
-        def __json__(self):
-            return ujson.encode(obj)
-
-    d = {"key": JSONTest()}
+    d = {"key": JSONTest(ujson.dumps(obj))}
     output = ujson.encode(d)
     dec = ujson.decode(output)
     assert dec == {"key": obj}
@@ -477,47 +472,47 @@ def test_object_with_complex_json():
 def test_object_with_json_type_error():
     # __json__ must return a string, otherwise it should raise an error.
     for return_value in (None, 1234, 12.34, True, {}):
-
-        class JSONTest:
-            def __json__(self):
-                return return_value
-
-        d = {"key": JSONTest()}
+        d = {"key": JSONTest(return_value)}
         with pytest.raises(TypeError):
             ujson.encode(d)
 
 
+class JSONTestAttributeError:
+    def __json__(self):
+        raise AttributeError
+
+
 def test_object_with_json_attribute_error():
     # If __json__ raises an error, make sure python actually raises it.
-    class JSONTest:
-        def __json__(self):
-            raise AttributeError
-
-    d = {"key": JSONTest()}
+    d = {"key": JSONTestAttributeError()}
     with pytest.raises(AttributeError):
         ujson.encode(d)
+
+
+class JSONtoDict:
+    def __init__(self, value):
+        self.value = value
+
+    def toDict(self):
+        return copy.deepcopy(self.value)
 
 
 def test_object_with_to_dict_type_error():
     # toDict must return a dict, otherwise it should raise an error.
     for return_value in (None, 1234, 12.34, True, "json"):
-
-        class JSONTest:
-            def toDict(self):
-                return return_value
-
-        d = {"key": JSONTest()}
+        d = {"key": JSONtoDict(return_value)}
         with pytest.raises(TypeError):
             ujson.encode(d)
 
 
+class JSONtoDictAttributeError:
+    def toDict(self):
+        raise AttributeError
+
+
 def test_object_with_to_dict_attribute_error():
     # If toDict raises an error, make sure python actually raises it.
-    class JSONTest:
-        def toDict(self):
-            raise AttributeError
-
-    d = {"key": JSONTest()}
+    d = {"key": JSONTestAttributeError()}
     with pytest.raises(AttributeError):
         ujson.encode(d)
 
@@ -645,6 +640,7 @@ def test_decode_numeric_int_exp(test_input):
     ],
 )
 @pytest.mark.parametrize("mode", ["encode", "decode"])
+@pytest.mark.skip_leak_test  # To be fixed separately
 def test_encode_decode_big_int(i, mode):
     # Test ints that are too large to be represented by a C integer type
     for python_object in (i, [i], {"i": i}):
@@ -1022,7 +1018,7 @@ def test_encode_special_keys():
     assert ujson.dumps(data, sort_keys=True) == '{"false":2,"true":1}'
 
 
-def test_default_function():
+class TestDefaultFunction:
     iso8601_time_format = "%Y-%m-%dT%H:%M:%S.%f"
 
     class CustomObject:
@@ -1031,30 +1027,36 @@ def test_default_function():
     class UnjsonableObject:
         pass
 
-    def default(value):
+    @classmethod
+    def default(cls, value):
         if isinstance(value, dt.datetime):
-            return value.strftime(iso8601_time_format)
+            return value.strftime(cls.iso8601_time_format)
         elif isinstance(value, uuid.UUID):
             return value.hex
-        elif isinstance(value, CustomObject):
+        elif isinstance(value, cls.CustomObject):
             raise ValueError("invalid value")
         return value
 
-    now = dt.datetime.now()
-    expected_output = '"%s"' % now.strftime(iso8601_time_format)
-    assert ujson.dumps(now, default=default) == expected_output
+    def test_datetime(self):
+        now = dt.datetime.now()
+        expected_output = '"%s"' % now.strftime(self.iso8601_time_format)
+        assert ujson.dumps(now, default=self.default) == expected_output
 
-    uuid4 = uuid.uuid4()
-    expected_output = '"%s"' % uuid4.hex
-    assert ujson.dumps(uuid4, default=default) == expected_output
+    def test_uuid(self):
+        uuid4 = uuid.uuid4()
+        expected_output = '"%s"' % uuid4.hex
+        assert ujson.dumps(uuid4, default=self.default) == expected_output
 
-    custom_obj = CustomObject()
-    with pytest.raises(ValueError, match="invalid value"):
-        ujson.dumps(custom_obj, default=default)
+    def test_exception_in_default(self):
+        custom_obj = self.CustomObject()
+        with pytest.raises(ValueError, match="invalid value"):
+            ujson.dumps(custom_obj, default=self.default)
 
-    unjsonable_obj = UnjsonableObject()
-    with pytest.raises(TypeError, match="maximum recursion depth exceeded"):
-        ujson.dumps(unjsonable_obj, default=default)
+    @pytest.mark.skip_leak_test  # Known memory leak
+    def test_recursive_default(self):
+        unjsonable_obj = self.UnjsonableObject()
+        with pytest.raises(TypeError, match="maximum recursion depth exceeded"):
+            ujson.dumps(unjsonable_obj, default=self.default)
 
 
 @pytest.mark.parametrize("indent", list(range(65537, 65542)))
@@ -1087,6 +1089,7 @@ def test_issue_334(indent):
     sys.implementation.name in ("pypy", "graalpy"),
     reason="PyPy & GraalPy use incompatible GC",
 )
+@pytest.mark.skip_leak_test  # Does its own leak checking
 def test_default_ref_counting():
     class DefaultRefCountingClass:
         def __init__(self, value):
@@ -1111,6 +1114,7 @@ def test_default_ref_counting():
     reason="GraalPy has an incompatible stub implementation of getrefcount",
 )
 @pytest.mark.parametrize("sort_keys", [False, True])
+@pytest.mark.skip_leak_test  # Does its own leak detection
 def test_obj_str_exception(sort_keys):
     class Obj:
         def __str__(self):
@@ -1223,18 +1227,20 @@ def test_loads_non_c_contiguous():
         ujson.loads(buffer)
 
 
-@pytest.mark.parametrize(
-    "enum_classes, value, expected",
-    [
-        ((enum.IntEnum,), 42, "42"),
-        ((float, enum.Enum), 3.1416, "3.1416"),
-    ],
-)
-def test_enum(enum_classes, value, expected):
-    class MyEnum(*enum_classes):
-        FOO = value
+class ExampleIntEnum(enum.IntEnum):
+    FOO = 42
 
-    assert ujson.dumps(MyEnum.FOO) == expected
+
+class ExampleFloatEnum(float, enum.Enum):
+    FOO = 3.1416
+
+
+@pytest.mark.parametrize(
+    "enum_class, expected",
+    [(ExampleIntEnum, "42"), (ExampleFloatEnum, "3.1416")],
+)
+def test_enum(enum_class, expected):
+    assert ujson.dumps(enum_class.FOO) == expected
 
 
 def test_nested_json_decode_error():


### PR DESCRIPTION
* Optionally run each test in a loop whilst watching tracemalloc.get_traced_memory() for unbounded increase in memory consumption.

* Avoid passing literally defined objects to ujson since they're effectively immortal (they exist as long as the function they're written in exists), hiding potential leaks by invisibly increasing that object's reference count instead of visibly leaking a new object each run.

* Move function and class definitions outside of test functions since, whilst they don't cause true leaks, it can take ~30,000 iterations for memory usage to plateau.

I did try various other forms of less ham-fisted leak detection like valgrind and -fsanitize=leak but I couldn't scope either of them to only what happens in ujson.
