### PR TITLE
Prevent integer overflow in indent handling (#700)

### DIFF
--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -743,8 +743,8 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       while (enc->iterNext(obj, &tc))
       {
-        // The extra 1 byte covers the optional newline.
-        Buffer_Reserve (enc, enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
+        // cast to size_t to prevent integer overflow on large indent values
+        Buffer_Reserve (enc, (size_t)enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
 
         if (count > 0)
         {
@@ -771,7 +771,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       if (count > 0) {
         // Reserve space for the indentation plus the newline.
-        Buffer_Reserve (enc, enc->indent * enc->level + 1);
+        Buffer_Reserve (enc, (size_t)enc->indent * enc->level + 1);
         Buffer_AppendIndentNewlineUnchecked (enc);
         Buffer_AppendIndentUnchecked (enc, enc->level);
       }
@@ -788,8 +788,8 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       while ((res = enc->iterNext(obj, &tc)))
       {
-        // The extra 1 byte covers the optional newline.
-        Buffer_Reserve (enc, enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
+        // cast to size_t to prevent integer overflow on large indent values
+        Buffer_Reserve (enc, (size_t)enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
 
         if(res < 0)
         {
@@ -824,7 +824,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       enc->iterEnd(obj, &tc);
 
       if (count > 0) {
-        Buffer_Reserve (enc, enc->indent * enc->level + 1);
+        Buffer_Reserve (enc, (size_t)enc->indent * enc->level + 1);
         Buffer_AppendIndentNewlineUnchecked (enc);
         Buffer_AppendIndentUnchecked (enc, enc->level);
       }

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -739,6 +739,17 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     encoder.sortKeys = 1;
   }
 
+  // clamp indent to a safe range - large values cause integer overflow
+  // in Buffer_Reserve arithmetic (see #700)
+  if (encoder.indent > 128)
+  {
+    encoder.indent = 128;
+  }
+  else if (encoder.indent < 0)
+  {
+    encoder.indent = 0;
+  }
+
   if (allowNan != -1)
   {
     encoder.allowNan = allowNan;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1064,6 +1064,20 @@ def test_dump_huge_indent(indent):
     ujson.encode({"a": True}, indent=indent)
 
 
+def test_large_indent_no_crash():
+    # regression test for #700 - integer overflow in Buffer_Reserve when
+    # indent * (level + 1) overflows int, causing heap buffer overflow
+    ujson.encode([[1]], indent=2**31 - 1)
+    ujson.encode({"a": {"b": 1}}, indent=2**31 - 1)
+
+
+def test_negative_indent_no_hang():
+    # negative indent values previously caused an infinite loop in the
+    # buffer resize path due to size_t underflow
+    ujson.encode([[1]], indent=-2000000000)
+    ujson.encode({"a": {"b": 1}}, indent=-2000000000)
+
+
 @pytest.mark.parametrize("first_length", list(range(2, 7)))
 @pytest.mark.parametrize("second_length", list(range(10919, 10924)))
 def test_dump_long_string(first_length, second_length):


### PR DESCRIPTION
fixes #700.

i filed this through a GHSA like you're supposed to. it got closed and i was told to use #700 instead. then when i commented on #700 for transparency, i got lectured about responsible disclosure. so let me get this straight: the proper channel gets shut down, i get redirected to the public issue, then get told off for being on the public issue. cool.

meanwhile the actual vulnerability has been sitting in the open with a full PoC, ASAN stacktrace, and the exact exploitable line number for a month. nobody seemed too worried about responsible disclosure then.

anyway, here's the fix. you're welcome.

### what was broken

the `indent` parameter has zero bounds checking. `ujson.encode({"a": [1]}, indent=2147483647)` causes `enc->indent * (enc->level + 1)` to overflow a 32-bit int in `Buffer_Reserve`, underallocating the buffer and giving you a heap buffer overflow confirmed by ASAN. `indent=-2000000000` causes an infinite loop because `size_t` underflow makes the buffer resize target unreachable. both have been trivially reproducible since forever.

### what this PR does

- **`ultrajsonenc.c`**: casts `enc->indent` to `size_t` before multiplication in all 4 `Buffer_Reserve` calls. belt and suspenders so the overflow can't happen even if validation is bypassed.
- - **`objToJSON.c`**: clamps `indent` to [0, 128] at the python layer. 128 spaces of indentation is already insane. negative values go to 0.
- - **`test_ujson.py`**: regression tests for both the segfault (`indent=2**31-1`) and the infinite hang (`indent=-2000000000`).
3 files, 31 lines added, 6 removed. minimal, tested, done.