### PR TITLE
Prevent CI workflows triggering twice on pull requests

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,6 @@
 name: Fuzz
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 permissions: {}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 permissions: {}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 permissions: {}
 


### PR DESCRIPTION
Remove the on push triggers which don't have any restrictions on branches or touched paths. They can still be triggered by a draft PR or manual trigger.