### PR TITLE
Fix buffer overflow/infinite loop from indent handling

### DIFF
--- a/src/ujson/lib/ultrajson.h
+++ b/src/ujson/lib/ultrajson.h
@@ -54,6 +54,7 @@ tree doesn't have cyclic references.
 #define __ULTRAJSON_H__
 
 #include <stdio.h>
+#include <stddef.h>
 
 // Max decimals to encode double floating point numbers with
 #ifndef JSON_DOUBLE_MAX_DECIMALS
@@ -257,7 +258,7 @@ typedef struct __JSONObjectEncoder
 
   /*
   Configuration for spaces of indent */
-  int indent;
+  ptrdiff_t indent;
 
   /*
   If true, NaN will be encoded as a string matching the Python standard library's JSON behavior.

--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -575,7 +575,7 @@ static void Buffer_AppendIndentNewlineUnchecked(JSONObjectEncoder *enc)
 
 static void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value)
 {
-  int i;
+  ptrdiff_t i;
   if (enc->indent > 0)
     while (value-- > 0)
       for (i = 0; i < enc->indent; i++)
@@ -741,10 +741,11 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       Buffer_AppendCharUnchecked (enc, '[');
 
+      // The extra 1 byte covers the optional newline.
+      size_t per_item_reserve = (enc->indent > 0 ? enc->indent : 0) * (enc->level + 1) + enc->itemSeparatorLength + 1;
       while (enc->iterNext(obj, &tc))
       {
-        // The extra 1 byte covers the optional newline.
-        Buffer_Reserve (enc, enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
+        Buffer_Reserve (enc, per_item_reserve);
 
         if (count > 0)
         {
@@ -769,7 +770,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       enc->iterEnd(obj, &tc);
 
-      if (count > 0) {
+      if (count > 0 && enc->indent > 0) {
         // Reserve space for the indentation plus the newline.
         Buffer_Reserve (enc, enc->indent * enc->level + 1);
         Buffer_AppendIndentNewlineUnchecked (enc);
@@ -786,10 +787,11 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       Buffer_AppendCharUnchecked (enc, '{');
 
+      // The extra 1 byte covers the optional newline.
+      size_t reserve_size = (enc->indent > 0 ? enc->indent : 0) * (enc->level + 1) + enc->itemSeparatorLength + 1;
       while ((res = enc->iterNext(obj, &tc)))
       {
-        // The extra 1 byte covers the optional newline.
-        Buffer_Reserve (enc, enc->indent * (enc->level + 1) + enc->itemSeparatorLength + 1);
+        Buffer_Reserve (enc, reserve_size);
 
         if(res < 0)
         {
@@ -823,7 +825,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       enc->iterEnd(obj, &tc);
 
-      if (count > 0) {
+      if (count > 0 && enc->indent > 0) {
         Buffer_Reserve (enc, enc->indent * enc->level + 1);
         Buffer_AppendIndentNewlineUnchecked (enc);
         Buffer_AppendIndentUnchecked (enc, enc->level);

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -678,6 +678,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *separatorsKeyBytes = NULL;
   int allowNan = -1;
   int orejectBytes = -1;
+  int indent = 0;
   size_t retLen;
 
   JSONObjectEncoder encoder =
@@ -714,7 +715,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOiiiOO", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &encoder.indent, &allowNan, &orejectBytes, &odefaultFn, &oseparators))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOiiiOO", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &indent, &allowNan, &orejectBytes, &odefaultFn, &oseparators))
   {
     return NULL;
   }
@@ -759,6 +760,19 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   if (orejectBytes != -1)
   {
     encoder.rejectBytes = orejectBytes;
+  }
+
+  if (indent < -1)
+  {
+    encoder.indent = -1;
+  }
+  else if (indent > 1000)
+  {
+    PyErr_SetString(PyExc_ValueError, "Maximum allowed indentation is 1000");
+    return NULL;
+  }
+  else {
+    encoder.indent = indent;
   }
 
   if (oseparators != NULL && oseparators != Py_None)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1059,9 +1059,25 @@ class TestDefaultFunction:
             ujson.dumps(unjsonable_obj, default=self.default)
 
 
-@pytest.mark.parametrize("indent", list(range(65537, 65542)))
+@pytest.mark.parametrize("indent", [999, 1000, 1001, 1 << 30, 1 << 63, 1 << 128])
 def test_dump_huge_indent(indent):
-    ujson.encode({"a": True}, indent=indent)
+    obj = {"list": [1, [2, 3], 4], "nested": {"key": "value", "a": True}}
+    if indent <= 1000:
+        assert ujson.loads(ujson.encode(obj, indent=indent)) == obj
+    else:
+        with pytest.raises((ValueError, OverflowError)):
+            ujson.encode(obj, indent=indent)
+
+
+def test_negative_indent():
+    obj = {"a": [1, 2], "b": "c"}
+    assert ujson.dumps(obj) == '{"a":[1,2],"b":"c"}'
+    assert ujson.dumps(obj, 0) == '{"a":[1,2],"b":"c"}'
+    assert ujson.dumps(obj, indent=-1) == '{"a": [1,2],"b": "c"}'
+    assert ujson.dumps(obj, indent=-1000000) == '{"a": [1,2],"b": "c"}'
+    assert (
+        ujson.dumps(obj, indent=2) == '{\n  "a": [\n    1,\n    2\n  ],\n  "b": "c"\n}'
+    )
 
 
 @pytest.mark.parametrize("first_length", list(range(2, 7)))


### PR DESCRIPTION
If `indent * nest_depth` is large enough to overflow an int, it causes the required output buffer size to be underestimated leading to a buffer overflow.

The offending arithmetic is upgraded to a `ptrdiff_t` and `indent` is artificially capped. An overflow is still technically possible given a high enough recursion depth but not without first consuming petabytes of RAM.

If indent is negative, it causes a `size_t` to underflow to some number a little bellow `size_t max`. If that underflow isn't accidentally rectified by a subsequent overflow (if `-indent * (nest_depth + 1) > current_buffer_size`) then the buffer up-sizer gets stuck in an infinite loop trying to find a power of two that fits in a `size_t` but is greater that `size_t max / 2`.

It's hard to tell if `ujson.dumps(..., indent=-1)` was ever an intentional feature but I don't feel comfortable breaking it in a security fix. For now, the dubious *any negative indent -> pad colons but add no indentation or newlines* behaviour is preserved but internally the indent is clipped to -1 and all subsequent indentation code paths are skipped over.

Fixes #700