### PR TITLE
Reduce bytes-like support to only bytes and bytearray

### DIFF
--- a/src/ujson/decode.c
+++ b/src/ujson/decode.c
@@ -850,7 +850,7 @@ PyObject* ujson_loads(PyObject* self, PyObject *args, PyObject *kwargs)
   {
     if (!PyBytes_Check(arg) && !PyByteArray_Check(arg)) {
       PyBuffer_Release(&buffer);
-      PyErr_Format(PyExc_TypeError, "Arbitrary bytes-like objects are no longer supported. Use either string, bytes, or bytearray");
+      PyErr_Format(PyExc_TypeError, "Arbitrary bytes-like objects are no longer supported. Use either string, bytes, or bytearray.");
       return NULL;
     }
     raw = buffer.buf;

--- a/src/ujson/decode.c
+++ b/src/ujson/decode.c
@@ -848,14 +848,11 @@ PyObject* ujson_loads(PyObject* self, PyObject *args, PyObject *kwargs)
   bool is_bytes_like = !PyObject_GetBuffer(arg, &buffer, PyBUF_C_CONTIGUOUS);
   if (is_bytes_like)
   {
-    #ifdef PYPY_VERSION
-      // PyPy's buffer protocol implementation is buggy: https://foss.heptapod.net/pypy/pypy/-/issues/3872
-      if (!PyBytes_Check(arg) && !PyByteArray_Check(arg)) {
-        PyBuffer_Release(&buffer);
-        PyErr_Format(PyExc_TypeError, "Arbitrary bytes-like objects are not supported on PyPy, Use either string, bytes, or bytearray");
-        return NULL;
-      }
-    #endif
+    if (!PyBytes_Check(arg) && !PyByteArray_Check(arg)) {
+      PyBuffer_Release(&buffer);
+      PyErr_Format(PyExc_TypeError, "Arbitrary bytes-like objects are no longer supported. Use either string, bytes, or bytearray");
+      return NULL;
+    }
     raw = buffer.buf;
     sarg_length = buffer.len;
   }
@@ -875,11 +872,7 @@ PyObject* ujson_loads(PyObject* self, PyObject *args, PyObject *kwargs)
     }
     else
     {
-      #ifdef PYPY_VERSION
-        PyErr_Format(PyExc_TypeError, "Expected string, bytes, or bytearray");
-      #else
-        PyErr_Format(PyExc_TypeError, "Expected string or C-contiguous bytes-like object");
-      #endif
+      PyErr_Format(PyExc_TypeError, "Expected string, bytes, or bytearray");
       return NULL;
     }
   }

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1641,18 +1641,10 @@ def test_separators_errors(separators, expected_exception):
 
 def test_loads_bytes_like():
     assert ujson.loads(b"123") == 123
-    if hasattr(sys, "pypy_version_info"):
-        with pytest.raises(TypeError, match="PyPy"):
-            ujson.loads(memoryview(b"{}"))
-    else:
-        assert ujson.loads(memoryview(b'["a", "b", "c"]')) == ["a", "b", "c"]
+    with pytest.raises(TypeError, match="Arbitrary bytes-like objects"):
+        ujson.loads(memoryview(b"{}"))
     assert ujson.loads(bytearray(b"99")) == 99
     assert ujson.loads('"🦄🐳"'.encode()) == "🦄🐳"
-    # array.array exports the C-contiguous buffer protocol and must be accepted.
-    import array as _array
-
-    if not hasattr(sys, "pypy_version_info"):
-        assert ujson.loads(_array.array("B", b'{"a":1}')) == {"a": 1}
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Other bytes-like objects lose the guarantee of being null-terminated which many points of the decoder rely on to detect truncated inputs. This allows the decoder to read past the end of its input for as long as the trash memory afterwards still looks like valid JSON:

    >>> ujson.loads(array.array("b", b'"truncated')[:3])
    ujson.JSONDecodeError: Found UTF-8 continuation byte without corresponding start byte when decoding 'string'

We could smother everything in bounds checking but for the sake of not over-complicating things souly for one feature that was more a byproduct of bytearray support anyway, just block such types. This effectively makes the PyPy path the only path.