### PR TITLE
Allow default handler to handle bytes

### DIFF
--- a/src/ujson/encode.c
+++ b/src/ujson/encode.c
@@ -431,19 +431,10 @@ BEGIN:
     return;
   }
   else
-  if (UNLIKELY(PyBytes_Check(obj)))
+  if (UNLIKELY(PyBytes_Check(obj) && !enc->rejectBytes))
   {
-    PRINTMARK();
-    if (enc->rejectBytes)
-    {
-      PyErr_Format (PyExc_TypeError, "reject_bytes is on and '%s' is bytes", PyBytes_AS_STRING(obj));
-      goto INVALID;
-    }
-    else
-    {
-      tc->PyTypeToJSON = PyStringToUTF8; tc->type = JT_UTF8;
-      return;
-    }
+    tc->PyTypeToJSON = PyStringToUTF8; tc->type = JT_UTF8;
+    return;
   }
   else
   if (PyUnicode_Check(obj))

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1324,7 +1324,7 @@ def test_reject_bytes_false():
 )
 def test_reject_bytes_nested(value):
     # reject_bytes=True (default) applies at any nesting depth.
-    with pytest.raises(TypeError, match="reject_bytes is on and"):
+    with pytest.raises(TypeError, match="b'(deep|hello)' is not JSON serializable"):
         ujson.dumps(value)
 
 
@@ -1460,6 +1460,11 @@ class TestDefaultFunction:
         with pytest.raises(TypeError, match="maximum recursion depth exceeded"):
             ujson.dumps(unjsonable_obj, default=self.default)
 
+    @pytest.mark.skip_leak_test  # Known memory leak
+    def test_recursive_default_bytes(self):
+        with pytest.raises(TypeError, match="maximum recursion depth exceeded"):
+            ujson.dumps(bytes(list(b"hello")), default=lambda x: x.decode().encode())
+
 
 @pytest.mark.parametrize("indent", [999, 1000, 1001, 1 << 30, 1 << 63, 1 << 128])
 def test_dump_huge_indent(indent):
@@ -1582,13 +1587,9 @@ def test_no_memory_leak_default_non_ascii():
     ujson.dumps(data, ensure_ascii=True, default=lambda o: non_ascii_value)
 
 
-@pytest.mark.skipif(
-    sys.implementation.name in ("pypy", "graalpy"),
-    reason="PyPy & GraalPy use incompatible GC",
-)
-@pytest.mark.parametrize("input", ['["a" * 11000, b""]'])
-def test_no_memory_leak_encoding_errors(input):
-    no_memory_leak(f"functools.partial(ujson.dumps, {input})")
+def test_no_memory_leak_encoding_errors():
+    with pytest.raises(TypeError, match="b'' is not JSON serializable"):
+        ujson.dumps(copy.deepcopy(["a" * 11000, b""]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Formerly if reject_bytes is false, bytes are assumed to be UTF-8 and if reject_bytes is true then bytes are assumed to be an error before checking if the default() function supports them.

Now when reject_bytes is true, bytes behave like every other unknown type and are left to the default() function to either convert to something else or continue to not handle.

Fixes #757